### PR TITLE
refactor: migrate to ID-based grouping and implement Section 7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,10 +34,7 @@ build/
 
 ### Custom ###
 output/
-src/main/resources/data/fieldData.json
-src/main/resources/data/operationsData.json
-src/main/resources/data/tmc.json
-src/main/resources/data/notesData.json
+src/main/resources/data/
 src/main/resources/application.yml
 src/main/resources/ids_for_payload.json
 cache

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
         <slf4j.version>2.0.17</slf4j.version>
         <openpdf.version>3.0.0</openpdf.version>
         <jackson-dataformat-yaml.version>2.21.2</jackson-dataformat-yaml.version>
+        <jsoup.version>1.22.1</jsoup.version>
     </properties>
 
     <dependencies>
@@ -69,6 +70,13 @@
             <version>${jackson-dataformat-yaml.version}</version>
         </dependency>
 
+        <dependency>
+            <!-- jsoup HTML parser library @ https://jsoup.org/ -->
+            <groupId>org.jsoup</groupId>
+            <artifactId>jsoup</artifactId>
+            <version>${jsoup.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -105,6 +113,20 @@
                 <configuration>
                     <mainClass>com.viking.field_passport_generator.Main</mainClass>
                 </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.3</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
         </plugins>

--- a/src/main/java/com/viking/field_passport_generator/Main.java
+++ b/src/main/java/com/viking/field_passport_generator/Main.java
@@ -21,18 +21,18 @@ public class Main {
         log.info("Application Started.");
         container.getSyncService().warmUp("data/notesData.json");
 
-        runMenu(container.getDataProvider(), container.getPdfService());
+        runMenu(container.getDataProvider(), container.getPassportGeneratorService());
     }
 
-    private static void runMenu(DataProvider dataProvider, PassportGeneratorService pdfService) {
+    private static void runMenu(DataProvider provider, PassportGeneratorService service) {
         while (true) {
             printMenu();
             String choice = scanner.nextLine();
 
             try {
                 switch (choice) {
-                    case "1" -> generateAll(dataProvider, pdfService);
-                    case "2" -> generateOne(dataProvider, pdfService);
+                    case "1" -> generateAll(provider, service);
+                    case "2" -> generateOne(provider, service);
                     case "0" -> {
                         log.info("Завершение работы...");
                         return;

--- a/src/main/java/com/viking/field_passport_generator/config/AppContainer.java
+++ b/src/main/java/com/viking/field_passport_generator/config/AppContainer.java
@@ -54,7 +54,7 @@ public class AppContainer {
 
         OperationMapper opMapper = new OperationMapper(timezone, threshold);
         NoteMapper noteMapper = new NoteMapper(timezone);
-        TechJournalMapper techMapper = new TechJournalMapper();
+        TechJournalMapper techMapper = new TechJournalMapper(config.getString("app.default-empty-label", "—"));
         FieldDataAggregator aggregator = new FieldDataAggregator(opMapper, noteMapper, techMapper, timezone);
 
         // DataProvider handles the retrieval and aggregation of field data

--- a/src/main/java/com/viking/field_passport_generator/config/AppContainer.java
+++ b/src/main/java/com/viking/field_passport_generator/config/AppContainer.java
@@ -5,7 +5,8 @@ import com.viking.field_passport_generator.data.provider.DataProvider;
 import com.viking.field_passport_generator.data.provider.FileDataProvider;
 import com.viking.field_passport_generator.http.ImageLoader;
 import com.viking.field_passport_generator.mapper.NoteMapper;
-import com.viking.field_passport_generator.mapper.OperationDataMapper;
+import com.viking.field_passport_generator.mapper.OperationMapper;
+import com.viking.field_passport_generator.mapper.TechJournalMapper;
 import com.viking.field_passport_generator.service.ImageCacheService;
 import com.viking.field_passport_generator.service.ImageSyncService;
 import com.viking.field_passport_generator.service.PassportGeneratorService;
@@ -20,7 +21,7 @@ import java.time.ZoneId;
 public class AppContainer {
     // Services ready for operation (getters provided below)
     private final DataProvider dataProvider;
-    private final PassportGeneratorService pdfService;
+    private final PassportGeneratorService passportGeneratorService;
     private final ImageSyncService syncService;
 
     public AppContainer(AppConfig config) {
@@ -34,12 +35,11 @@ public class AppContainer {
 
         // --- 2. Image Processing Layer ---
         // Configure image loading, caching, and synchronization
-        String userAgent = config.getString("agro.api.user-agent");
         ImageLoader imageLoader = new ImageLoader(
                 httpClient,
                 config.getString("agro.api.base-url"),
                 config.getString("agro.api.key"),
-                userAgent,
+                config.getString("agro.api.user-agent"),
                 config.getString("agro.api.endpoints.attachments-info")
         );
 
@@ -49,12 +49,13 @@ public class AppContainer {
 
         // --- 3. Data Processing Layer (Mappers & Aggregators) ---
         // Convert raw configuration strings into typed domain objects
-        ZoneId zone = ZoneId.of(config.getString("app.timezone", "Asia/Krasnoyarsk"));
+        ZoneId timezone = ZoneId.of(config.getString("app.timezone", "Asia/Krasnoyarsk"));
         Duration threshold = Duration.ofHours(config.getInt("app.threshold-hours", 48));
 
-        OperationDataMapper opMapper = new OperationDataMapper(zone, threshold);
-        NoteMapper noteMapper = new NoteMapper(zone);
-        FieldDataAggregator aggregator = new FieldDataAggregator(opMapper, noteMapper);
+        OperationMapper opMapper = new OperationMapper(timezone, threshold);
+        NoteMapper noteMapper = new NoteMapper(timezone);
+        TechJournalMapper techMapper = new TechJournalMapper();
+        FieldDataAggregator aggregator = new FieldDataAggregator(opMapper, noteMapper, techMapper, timezone);
 
         // DataProvider handles the retrieval and aggregation of field data
         this.dataProvider = new FileDataProvider(jsonParser, aggregator);
@@ -66,7 +67,7 @@ public class AppContainer {
         // Convert Megabytes from config to Bytes for internal safety checks
         long minSpaceBytes = (long) config.getInt("app.min-free-space-mb", 1024) * 1024 * 1024;
 
-        this.pdfService = new PdfGeneratorService(
+        this.passportGeneratorService = new PdfGeneratorService(
                 cacheService::getImageBytes, // Functional interface for decoupled image retrieval
                 minSpaceBytes,
                 outputDir
@@ -75,6 +76,6 @@ public class AppContainer {
 
     // Getters for Main entry point
     public DataProvider getDataProvider() { return dataProvider; }
-    public PassportGeneratorService getPdfService() { return pdfService; }
+    public PassportGeneratorService getPassportGeneratorService() { return passportGeneratorService; }
     public ImageSyncService getSyncService() { return syncService; }
 }

--- a/src/main/java/com/viking/field_passport_generator/data/aggregator/FieldDataAggregator.java
+++ b/src/main/java/com/viking/field_passport_generator/data/aggregator/FieldDataAggregator.java
@@ -1,68 +1,93 @@
 package com.viking.field_passport_generator.data.aggregator;
 
+import com.viking.field_passport_generator.data.dictionary.MachineDictionary;
 import com.viking.field_passport_generator.data.dictionary.TmcDictionary;
 import com.viking.field_passport_generator.data.dto.*;
 import com.viking.field_passport_generator.mapper.NoteMapper;
-import com.viking.field_passport_generator.mapper.OperationDataMapper;
+import com.viking.field_passport_generator.mapper.OperationMapper;
 import com.viking.field_passport_generator.mapper.PassportMapper;
+import com.viking.field_passport_generator.mapper.TechJournalMapper;
 import com.viking.field_passport_generator.model.FieldPassport;
 import com.viking.field_passport_generator.model.NoteSection;
 import com.viking.field_passport_generator.model.OperationTableRow;
+import com.viking.field_passport_generator.model.TechJournalTableRow;
 import com.viking.field_passport_generator.util.YearUtils;
 
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class FieldDataAggregator {
-    private final OperationDataMapper operationMapper;
+    private final OperationMapper operationMapper;
     private final NoteMapper noteMapper;
+    private final TechJournalMapper techJournalMapper;
+    private final ZoneId timezone;
 
-    public FieldDataAggregator(OperationDataMapper operationMapper, NoteMapper noteMapper) {
+    public FieldDataAggregator(OperationMapper operationMapper, NoteMapper noteMapper,
+                               TechJournalMapper techJournalMapper, ZoneId timezone) {
         this.operationMapper = operationMapper;
         this.noteMapper = noteMapper;
+        this.techJournalMapper = techJournalMapper;
+        this.timezone = timezone;
     }
 
-    public List<FieldPassport> aggregate(RawApiResponse fieldsResponse,
-                                         RawOperationsResponse opsResponse,
-                                         RawGoodsResponse goodsResponse, RawNotesResponse notesResponse) {
+    public List<FieldPassport> aggregate(RawApiResponse fieldsResponse, RawOperationsResponse opsResponse,
+                                         RawGoodsResponse goodsResponse, RawNotesResponse notesResponse,
+                                         RawMachineResponse machineResponse) {
 
         TmcDictionary tmcDictionary = new TmcDictionary(goodsResponse.data());
+        MachineDictionary machineDictionary = new MachineDictionary(machineResponse.data());
 
-        Map<String, List<RawOperationData>> opsByFieldName = opsResponse.data().stream()
-                .filter(op -> op.getGeoZone() != null)
-                .collect(Collectors.groupingBy(RawOperationData::getGeoZone));
+        Map<Long, List<RawOperationData>> opsByFieldId = opsResponse.data().stream()
+                .filter(op -> op.getFieldId() != null)
+                .collect(Collectors.groupingBy(RawOperationData::getFieldId));
 
-        Map<String, List<RawNote>> notesByFieldId = new HashMap<>();
+        Map<Long, List<RawNote>> notesByFieldId = new HashMap<>();
         for (RawNote note : notesResponse.data()) {
-            List<String> sources = note.sources();
-            if (sources != null) {
-                for (String fieldId : sources) {
-                    notesByFieldId.computeIfAbsent(fieldId, k -> new ArrayList<>()).add(note);
+            if (note.sources() != null) {
+                for (String sourceIdStr :  note.sources()) {
+                    try {
+                        Long fId = Long.valueOf(sourceIdStr);
+                        notesByFieldId.computeIfAbsent(fId, v -> new ArrayList<>()).add(note);
+                    } catch (NumberFormatException ignored) {}
                 }
             }
         }
 
         return fieldsResponse.data().stream()
-                .map(rawField -> buildPassport(rawField, opsByFieldName, tmcDictionary, notesByFieldId))
+                .map(rawField -> buildPassport(rawField, opsByFieldId, tmcDictionary,
+                        machineDictionary, notesByFieldId))
                 .collect(Collectors.toList());
     }
 
     private FieldPassport buildPassport(RawFieldData rawField,
-                                        Map<String, List<RawOperationData>> opsByFieldName,
-                                        TmcDictionary tmcDictionary,
-                                        Map<String, List<RawNote>> notesByFieldId) {
-        String fieldName = rawField.field();
-        String passportYear = YearUtils.extractYear(rawField.crop());
-        List<RawOperationData> fieldOps = opsByFieldName.getOrDefault(fieldName, Collections.emptyList());
-        List<OperationTableRow> tableRows = operationMapper.mapToTableRow(
-                fieldOps, fieldName, passportYear, tmcDictionary
-        );
-
-        String fieldId = rawField.fieldId();
+                                        Map<Long, List<RawOperationData>> opsByFieldId,
+                                        TmcDictionary tmcDictionary, MachineDictionary machineDictionary,
+                                        Map<Long, List<RawNote>> notesByFieldId) {
+        Long fieldId = rawField.fieldId();
+        int passportYear = Integer.parseInt(YearUtils.extractYear(rawField.crop()));
+        List<RawOperationData> cleanOps = filterOperationsByYear(opsByFieldId.getOrDefault(fieldId, List.of()), passportYear);
         List<RawNote> fieldNotes = notesByFieldId.getOrDefault(fieldId, Collections.emptyList());
-        NoteSection noteSection = noteMapper.map(fieldNotes, passportYear);
+        List<OperationTableRow> operationTableRows = operationMapper.mapToTableRow(cleanOps, tmcDictionary);
+        NoteSection noteSection = noteMapper.map(fieldNotes, String.valueOf(passportYear));
+        List<TechJournalTableRow> techJournalTableRows = techJournalMapper.mapToTableRow(cleanOps, machineDictionary);
 
+        return PassportMapper.mapToDomain(rawField, operationTableRows, noteSection, techJournalTableRows);
+    }
 
-        return PassportMapper.mapToDomain(rawField, tableRows, noteSection);
+    private List<RawOperationData> filterOperationsByYear(List<RawOperationData> ops, int targetYear) {
+        return ops.stream()
+                .filter(RawOperationData::isValid)
+                .filter(r -> r.getArea() != null && r.getArea() > 0)
+                .filter(r -> {
+                    ZonedDateTime zdt = ZonedDateTime.ofInstant(
+                            Instant.ofEpochMilli(r.getStartTime()), timezone);
+                    return zdt.getYear() == targetYear;
+                })
+                .sorted(Comparator.comparing(RawOperationData::getOperation)
+                        .thenComparing(RawOperationData::getStartTime))
+                .toList();
     }
 }

--- a/src/main/java/com/viking/field_passport_generator/data/aggregator/FieldDataAggregator.java
+++ b/src/main/java/com/viking/field_passport_generator/data/aggregator/FieldDataAggregator.java
@@ -80,7 +80,7 @@ public class FieldDataAggregator {
                                         TmcDictionary tmcDictionary, MachineDictionary machineDictionary,
                                         Map<Long, List<RawNote>> notesByFieldId) {
         Long fieldId = rawField.fieldId();
-        int passportYear = Integer.parseInt(YearUtils.extractYear(rawField.crop()));
+        int passportYear = YearUtils.extractYear(rawField.crop());
         List<RawOperationData> cleanOps = filterOperationsByYear(opsByFieldId.getOrDefault(fieldId, List.of()), passportYear);
         List<RawNote> fieldNotes = notesByFieldId.getOrDefault(fieldId, Collections.emptyList());
         List<OperationTableRow> operationTableRows = operationMapper.mapToTableRow(cleanOps, tmcDictionary);

--- a/src/main/java/com/viking/field_passport_generator/data/aggregator/FieldDataAggregator.java
+++ b/src/main/java/com/viking/field_passport_generator/data/aggregator/FieldDataAggregator.java
@@ -12,6 +12,8 @@ import com.viking.field_passport_generator.model.NoteSection;
 import com.viking.field_passport_generator.model.OperationTableRow;
 import com.viking.field_passport_generator.model.TechJournalTableRow;
 import com.viking.field_passport_generator.util.YearUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -24,6 +26,7 @@ public class FieldDataAggregator {
     private final NoteMapper noteMapper;
     private final TechJournalMapper techJournalMapper;
     private final ZoneId timezone;
+    private static final Logger log = LoggerFactory.getLogger(FieldDataAggregator.class);
 
     public FieldDataAggregator(OperationMapper operationMapper, NoteMapper noteMapper,
                                TechJournalMapper techJournalMapper, ZoneId timezone) {
@@ -46,12 +49,22 @@ public class FieldDataAggregator {
 
         Map<Long, List<RawNote>> notesByFieldId = new HashMap<>();
         for (RawNote note : notesResponse.data()) {
-            if (note.sources() != null) {
-                for (String sourceIdStr :  note.sources()) {
-                    try {
-                        Long fId = Long.valueOf(sourceIdStr);
-                        notesByFieldId.computeIfAbsent(fId, v -> new ArrayList<>()).add(note);
-                    } catch (NumberFormatException ignored) {}
+            if (note.sources() == null) {
+                continue;
+            }
+            for (String sourceIdStr :  note.sources()) {
+                if (sourceIdStr == null || sourceIdStr.isBlank()) {
+                    continue;
+                }
+                String cleanId = sourceIdStr.trim();
+                if (cleanId.isEmpty()) {
+                    continue;
+                }
+                try {
+                    Long fId = Long.valueOf(cleanId);
+                    notesByFieldId.computeIfAbsent(fId, v -> new ArrayList<>()).add(note);
+                } catch (NumberFormatException e) {
+                    log.warn("Could not parse note source ID '{}' as a Long.", cleanId);
                 }
             }
         }
@@ -80,7 +93,6 @@ public class FieldDataAggregator {
     private List<RawOperationData> filterOperationsByYear(List<RawOperationData> ops, int targetYear) {
         return ops.stream()
                 .filter(RawOperationData::isValid)
-                .filter(r -> r.getArea() != null && r.getArea() > 0)
                 .filter(r -> {
                     ZonedDateTime zdt = ZonedDateTime.ofInstant(
                             Instant.ofEpochMilli(r.getStartTime()), timezone);

--- a/src/main/java/com/viking/field_passport_generator/data/dictionary/MachineDictionary.java
+++ b/src/main/java/com/viking/field_passport_generator/data/dictionary/MachineDictionary.java
@@ -8,9 +8,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static com.viking.field_passport_generator.util.StringUtils.clean;
+
 public class MachineDictionary {
     private final Map<Long, MachineResource> dictionary;
-    private static final String NOT_AVAILABLE = "Техника не определена";
 
     public MachineDictionary(List<MachineResource> machines) {
         this.dictionary = machines.stream()
@@ -20,23 +21,6 @@ public class MachineDictionary {
                         machine -> machine,
                         (existing, replacement) -> existing
                 ));
-    }
-
-    public String getMachineFullTitle(Long id) {
-        MachineResource machine = dictionary.get(id);
-        if (machine == null) return "";
-
-        String inv = machine.inventoryNumber();
-
-        String cleanNum = Arrays.stream(machine.number().split(" "))
-                .filter(word -> !word.equalsIgnoreCase(inv))
-                .collect(Collectors.joining(" "));
-
-        return Stream.of(machine.unitTypeName(), getBestModelName(machine), cleanNum, inv)
-                .filter(s -> !s.isEmpty())
-                .distinct()
-                .collect(Collectors.joining(" "));
-
     }
 
     private MachineResource normalize(MachineResource machine) {
@@ -50,23 +34,10 @@ public class MachineDictionary {
         );
     }
 
-    private String getBestModelName(MachineResource machine) {
-        return machine.unitModelName().isEmpty() ? machine.model() : machine.unitModelName();
-    }
-
-    public String clean(String s) {
-        if (s == null || s.isBlank() || s.equalsIgnoreCase("null")) {
-            return "";
-        }
-        return s.trim().replaceAll("\\s+", " ");
-    }
-
     public MachineResource getById(Long id) {
         if (id == null) {
             return MachineResource.unknown(0L);
         }
         return dictionary.getOrDefault(id, MachineResource.unknown(id));
     }
-
-
 }

--- a/src/main/java/com/viking/field_passport_generator/data/dictionary/MachineDictionary.java
+++ b/src/main/java/com/viking/field_passport_generator/data/dictionary/MachineDictionary.java
@@ -1,0 +1,72 @@
+package com.viking.field_passport_generator.data.dictionary;
+
+import com.viking.field_passport_generator.model.MachineResource;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class MachineDictionary {
+    private final Map<Long, MachineResource> dictionary;
+    private static final String NOT_AVAILABLE = "Техника не определена";
+
+    public MachineDictionary(List<MachineResource> machines) {
+        this.dictionary = machines.stream()
+                .map(this::normalize)
+                .collect(Collectors.toMap(
+                        MachineResource::id,
+                        machine -> machine,
+                        (existing, replacement) -> existing
+                ));
+    }
+
+    public String getMachineFullTitle(Long id) {
+        MachineResource machine = dictionary.get(id);
+        if (machine == null) return "";
+
+        String inv = machine.inventoryNumber();
+
+        String cleanNum = Arrays.stream(machine.number().split(" "))
+                .filter(word -> !word.equalsIgnoreCase(inv))
+                .collect(Collectors.joining(" "));
+
+        return Stream.of(machine.unitTypeName(), getBestModelName(machine), cleanNum, inv)
+                .filter(s -> !s.isEmpty())
+                .distinct()
+                .collect(Collectors.joining(" "));
+
+    }
+
+    private MachineResource normalize(MachineResource machine) {
+        return new MachineResource(
+                machine.id(),
+                clean(machine.unitTypeName()),
+                clean(machine.unitModelName()),
+                clean(machine.model()),
+                clean(machine.number()),
+                clean(machine.inventoryNumber())
+        );
+    }
+
+    private String getBestModelName(MachineResource machine) {
+        return machine.unitModelName().isEmpty() ? machine.model() : machine.unitModelName();
+    }
+
+    public String clean(String s) {
+        if (s == null || s.isBlank() || s.equalsIgnoreCase("null")) {
+            return "";
+        }
+        return s.trim().replaceAll("\\s+", " ");
+    }
+
+    public MachineResource getById(Long id) {
+        if (id == null) {
+            return MachineResource.unknown(0L);
+        }
+        return dictionary.getOrDefault(id, MachineResource.unknown(id));
+    }
+
+
+}

--- a/src/main/java/com/viking/field_passport_generator/data/dictionary/TmcDictionary.java
+++ b/src/main/java/com/viking/field_passport_generator/data/dictionary/TmcDictionary.java
@@ -14,7 +14,11 @@ public class TmcDictionary {
 
     public TmcDictionary(List<TmcDictItem> items) {
         this.tmcDictionary = items.stream()
-                .collect(Collectors.toConcurrentMap(TmcDictItem::id, item -> item));
+                .collect(Collectors.toConcurrentMap(
+                        TmcDictItem::id,
+                        item -> item,
+                        (existing, replacement) -> existing
+                ));
     }
 
     public String getName(Long id) {

--- a/src/main/java/com/viking/field_passport_generator/data/dto/RawFieldData.java
+++ b/src/main/java/com/viking/field_passport_generator/data/dto/RawFieldData.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record RawFieldData(
     String department,
-    @JsonProperty("sourceId") String fieldId,
+    @JsonProperty("sourceId") Long fieldId,
     String field,
     double fieldArea,
     String crop,

--- a/src/main/java/com/viking/field_passport_generator/data/dto/RawMachineResponse.java
+++ b/src/main/java/com/viking/field_passport_generator/data/dto/RawMachineResponse.java
@@ -1,0 +1,10 @@
+package com.viking.field_passport_generator.data.dto;
+
+import com.viking.field_passport_generator.model.MachineResource;
+
+import java.util.List;
+
+public record RawMachineResponse(
+        List<MachineResource> data
+) {
+}

--- a/src/main/java/com/viking/field_passport_generator/data/dto/RawOperationData.java
+++ b/src/main/java/com/viking/field_passport_generator/data/dto/RawOperationData.java
@@ -14,7 +14,8 @@ import java.util.regex.Pattern;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RawOperationData {
-    @JsonProperty("geoZoneId") Long fieldId;
+    @JsonProperty("geoZoneId")
+    private Long fieldId;
     private String geoZone;
     private Long operationId;
     private String operation;

--- a/src/main/java/com/viking/field_passport_generator/data/dto/RawOperationData.java
+++ b/src/main/java/com/viking/field_passport_generator/data/dto/RawOperationData.java
@@ -4,15 +4,17 @@ package com.viking.field_passport_generator.data.dto;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RawOperationData {
-    private Long geoZoneId;
+    @JsonProperty("geoZoneId") Long fieldId;
     private String geoZone;
     private Long operationId;
     private String operation;
@@ -25,16 +27,29 @@ public class RawOperationData {
     private Double avgSpeed;
     private String seasons;
     private String fieldTool;
+    private List<Long> fieldToolIds;
     private String driver;
+    private Long unitId;
+    private String date;
+    private Long mTime;
+
+    @JsonProperty("period")
+    private void unpackPeriod(Map<String, Object> period) {
+        if (period == null) return;
+        this.date = (String) period.get("date");
+        Object mTimeVal = period.get("mTime");
+        if (mTimeVal instanceof Number) {
+            this.mTime = ((Number) mTimeVal).longValue();
+        }
+    }
+
 
     private static final Pattern TMC_ID_PATTERN = Pattern.compile("_(\\d+)$");
     private static final String TMC_PREFIX = "fact_qwn_";
 
     private final Map<String, Object> tmcFields = new HashMap<>();
 
-    public RawOperationData() {
-
-    }
+    public RawOperationData() {}
 
     @JsonAnySetter
     public void setDynamicField(String key, Object value) {
@@ -63,18 +78,7 @@ public class RawOperationData {
                 area != null && area > 0;
     }
 
-
-    public Long getGeoZoneId() {
-        return geoZoneId;
-    }
-
-    public void setGeoZoneId(Long geoZoneId) {
-        this.geoZoneId = geoZoneId;
-    }
-
-    public String getGeoZone() {
-        return geoZone;
-    }
+    public String getGeoZone() { return geoZone; }
 
     public void setGeoZone(String geoZone) {
         this.geoZone = geoZone;
@@ -175,5 +179,29 @@ public class RawOperationData {
     public void setDriver(String driver) {
         this.driver = driver;
     }
+
+    public List<Long> getFieldToolIds() {
+        return fieldToolIds;
+    }
+
+    public void setFieldToolIds(List<Long> fieldToolIds) {
+        this.fieldToolIds = fieldToolIds;
+    }
+
+    public Long getUnitId() { return unitId; }
+
+    public void setUnitId(Long unitId) {
+        this.unitId = unitId;
+    }
+
+    public Long getFieldId() {
+        return fieldId;
+    }
+
+    public void setFieldId(Long fieldId) { this.fieldId = fieldId; }
+
+    public String getDate() { return date; }
+
+    public Long getmTime() { return mTime; }
 }
 

--- a/src/main/java/com/viking/field_passport_generator/data/dto/RawOperationData.java
+++ b/src/main/java/com/viking/field_passport_generator/data/dto/RawOperationData.java
@@ -202,6 +202,6 @@ public class RawOperationData {
 
     public String getDate() { return date; }
 
-    public Long getmTime() { return mTime; }
+    public Long getMTime() { return mTime; }
 }
 

--- a/src/main/java/com/viking/field_passport_generator/data/provider/FileDataProvider.java
+++ b/src/main/java/com/viking/field_passport_generator/data/provider/FileDataProvider.java
@@ -2,10 +2,7 @@ package com.viking.field_passport_generator.data.provider;
 
 
 import com.viking.field_passport_generator.data.aggregator.FieldDataAggregator;
-import com.viking.field_passport_generator.data.dto.RawApiResponse;
-import com.viking.field_passport_generator.data.dto.RawGoodsResponse;
-import com.viking.field_passport_generator.data.dto.RawNotesResponse;
-import com.viking.field_passport_generator.data.dto.RawOperationsResponse;
+import com.viking.field_passport_generator.data.dto.*;
 import com.viking.field_passport_generator.model.FieldPassport;
 import com.viking.field_passport_generator.util.JsonDataParser;
 import com.viking.field_passport_generator.util.ResourceReader;
@@ -31,14 +28,18 @@ public class FileDataProvider implements DataProvider {
         try (InputStream fieldsIs = ResourceReader.readAsStream("data/fieldData.json");
              InputStream operationIs = ResourceReader.readAsStream("data/operationsData.json");
              InputStream tmcIs = ResourceReader.readAsStream("data/tmc.json");
-             InputStream notesIs = ResourceReader.readAsStream("data/notesData.json")) {
+             InputStream notesIs = ResourceReader.readAsStream("data/notesData.json");
+             InputStream unitsIs = ResourceReader.readAsStream("data/units.json") ) {
 
             RawApiResponse fieldsResponse = jsonDataParser.parse(fieldsIs, RawApiResponse.class);
             RawOperationsResponse opsResponse = jsonDataParser.parse(operationIs, RawOperationsResponse.class);
             RawGoodsResponse goodsResponse = jsonDataParser.parse(tmcIs, RawGoodsResponse.class);
             RawNotesResponse notesResponse = jsonDataParser.parse(notesIs, RawNotesResponse.class);
+            RawMachineResponse machineResponse = jsonDataParser.parse(unitsIs, RawMachineResponse.class);
 
-            return aggregator.aggregate(fieldsResponse, opsResponse, goodsResponse, notesResponse);
+
+
+            return aggregator.aggregate(fieldsResponse, opsResponse, goodsResponse, notesResponse, machineResponse);
         } catch (Exception e) {
             log.error("Failed to load and aggregate passport data from resources", e);
             throw new RuntimeException("Failed to load and aggregate passport data from resources", e);

--- a/src/main/java/com/viking/field_passport_generator/mapper/NoteMapper.java
+++ b/src/main/java/com/viking/field_passport_generator/mapper/NoteMapper.java
@@ -33,11 +33,9 @@ public class NoteMapper {
             }
         }
 
-
         if (filteredNotes.isEmpty()) {
             return new NoteSection(Collections.emptyList(), Collections.emptyList());
         }
-
 
         filteredNotes.sort(Comparator.comparing(RawNote::createdAt)
                 .thenComparing(RawNote::updatedAt).reversed());

--- a/src/main/java/com/viking/field_passport_generator/mapper/OperationMapper.java
+++ b/src/main/java/com/viking/field_passport_generator/mapper/OperationMapper.java
@@ -12,37 +12,20 @@ import java.time.ZonedDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class OperationDataMapper {
+public class OperationMapper {
     private final ZoneId timezone;
     private final long aggregationThresholdMs;
 
-    public OperationDataMapper(ZoneId timezone, Duration threshold) {
+    public OperationMapper(ZoneId timezone, Duration threshold) {
         this.timezone = Objects.requireNonNull(timezone, "Timezone must not be null");
         this.aggregationThresholdMs = Objects.requireNonNull(threshold, "Threshold must not be null").toMillis();
     }
 
     public List<OperationTableRow> mapToTableRow(
             List<RawOperationData> rawData,
-            String targetFieldName,
-            String passportYear,
             TmcDictionary tmcDictionary) {
 
-        int targetYear = Integer.parseInt(passportYear);
-        List<RawOperationData> filtered = rawData.stream()
-                .filter(RawOperationData::isValid)
-                .filter(r -> r.getArea() != null && r.getArea() > 0)
-                .filter(r -> targetFieldName.equals(r.getGeoZone()))
-                .filter(r -> {ZonedDateTime zdt = ZonedDateTime.ofInstant(
-                        Instant.ofEpochMilli(r.getStartTime()), timezone);
-                    return zdt.getYear() == targetYear;
-                })
-                .sorted(Comparator.comparing(RawOperationData::getOperation)
-                        .thenComparing(RawOperationData::getStartTime))
-                .toList();
-
-        if (filtered.isEmpty()) return Collections.emptyList();
-
-        List<OperationAccumulator> groups = groupByOperation(filtered);
+        List<OperationAccumulator> groups = groupByOperation(rawData);
 
         return groups.stream()
                 .map(g -> g.toTableRow(tmcDictionary))

--- a/src/main/java/com/viking/field_passport_generator/mapper/PassportMapper.java
+++ b/src/main/java/com/viking/field_passport_generator/mapper/PassportMapper.java
@@ -19,8 +19,7 @@ public class PassportMapper {
             NoteSection noteSection, List<TechJournalTableRow> techJournal) {
         String rawCrop = raw.crop();
 
-        String yearStr = YearUtils.extractYear(rawCrop);
-        int year = yearStr.isEmpty() ? -1 : Integer.parseInt(yearStr);
+        int year = YearUtils.extractYear(rawCrop);
 
         if (year == -1) {
             log.warn("Год не найден в описании культуры поля {}: '{}'", raw.field(), rawCrop);

--- a/src/main/java/com/viking/field_passport_generator/mapper/PassportMapper.java
+++ b/src/main/java/com/viking/field_passport_generator/mapper/PassportMapper.java
@@ -15,10 +15,8 @@ public class PassportMapper {
     /**
      * Превращает сырые данные поля и подготовленный список операций в доменный объект паспорта.
      */
-    public static FieldPassport mapToDomain(
-            RawFieldData raw,
-            List<OperationTableRow> operations,
-            NoteSection noteSection) {
+    public static FieldPassport mapToDomain(RawFieldData raw, List<OperationTableRow> operations,
+            NoteSection noteSection, List<TechJournalTableRow> techJournal) {
         String rawCrop = raw.crop();
 
         String yearStr = YearUtils.extractYear(rawCrop);
@@ -43,7 +41,8 @@ public class PassportMapper {
         return new FieldPassport(
                 info,
                 operations != null ? operations : Collections.emptyList(),
-                noteSection != null ? noteSection : new NoteSection(Collections.emptyList(), Collections.emptyList())
+                noteSection != null ? noteSection : new NoteSection(Collections.emptyList(), Collections.emptyList()),
+                techJournal != null ? techJournal : Collections.emptyList()
         );
     }
 }

--- a/src/main/java/com/viking/field_passport_generator/mapper/TechJournalMapper.java
+++ b/src/main/java/com/viking/field_passport_generator/mapper/TechJournalMapper.java
@@ -12,7 +12,15 @@ import org.jsoup.nodes.TextNode;
 import java.util.Comparator;
 import java.util.List;
 
+import static com.viking.field_passport_generator.util.StringUtils.clean;
+import static com.viking.field_passport_generator.util.StringUtils.normalize;
+
 public class TechJournalMapper {
+    private final String emptyLabel;
+
+    public TechJournalMapper(String emptyLabel) {
+        this.emptyLabel = emptyLabel;
+    }
 
     public List<TechJournalTableRow> mapToTableRow(List<RawOperationData> cleanOps,
                                                    MachineDictionary machineDict){
@@ -20,16 +28,17 @@ public class TechJournalMapper {
         if (cleanOps == null || cleanOps.isEmpty()) return List.of();
 
         return cleanOps.stream()
-                .sorted(Comparator.comparing(RawOperationData::getmTime))
+                .sorted(Comparator.comparing(RawOperationData::getMTime, Comparator.nullsLast(Comparator.naturalOrder())))
                         .map(op -> {
                             MachineResource machine = machineDict.getById(op.getUnitId());
-                            String fieldTool = op.getFieldTool();
-                            String cleanDate = cleanHtml(op.getDate());
+                            String fieldTool = clean(op.getFieldTool());
+                            String cleanDate = normalize(cleanHtml(op.getDate()), emptyLabel);
+                            String cleanDriver = normalize(op.getDriver(), emptyLabel);
 
                             return new TechJournalTableRow(
                                     machine,
                                     fieldTool,
-                                    op.getDriver() != null ? op.getDriver() : "Не указан",
+                                    cleanDriver,
                                     cleanDate
                             );
                         }).toList();

--- a/src/main/java/com/viking/field_passport_generator/mapper/TechJournalMapper.java
+++ b/src/main/java/com/viking/field_passport_generator/mapper/TechJournalMapper.java
@@ -1,0 +1,46 @@
+package com.viking.field_passport_generator.mapper;
+
+import com.viking.field_passport_generator.data.dictionary.MachineDictionary;
+import com.viking.field_passport_generator.data.dto.RawOperationData;
+import com.viking.field_passport_generator.model.MachineResource;
+import com.viking.field_passport_generator.model.TechJournalTableRow;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.nodes.TextNode;
+
+import java.util.Comparator;
+import java.util.List;
+
+public class TechJournalMapper {
+
+    public List<TechJournalTableRow> mapToTableRow(List<RawOperationData> cleanOps,
+                                                   MachineDictionary machineDict){
+
+        if (cleanOps == null || cleanOps.isEmpty()) return List.of();
+
+        return cleanOps.stream()
+                .sorted(Comparator.comparing(RawOperationData::getmTime))
+                        .map(op -> {
+                            MachineResource machine = machineDict.getById(op.getUnitId());
+                            String fieldTool = op.getFieldTool();
+                            String cleanDate = cleanHtml(op.getDate());
+
+                            return new TechJournalTableRow(
+                                    machine,
+                                    fieldTool,
+                                    op.getDriver() != null ? op.getDriver() : "Не указан",
+                                    cleanDate
+                            );
+                        }).toList();
+    }
+
+    private String cleanHtml(String html) {
+        if (html == null || html.isBlank()) return "";
+        Document doc = Jsoup.parseBodyFragment(html);
+        for (Element br : doc.select("br")) {
+            br.replaceWith(new TextNode(" "));
+        }
+        return doc.body().text().trim();
+    }
+}

--- a/src/main/java/com/viking/field_passport_generator/model/FieldPassport.java
+++ b/src/main/java/com/viking/field_passport_generator/model/FieldPassport.java
@@ -5,5 +5,6 @@ import java.util.List;
 public record FieldPassport(
     GeneralInfo generalInfo,
     List<OperationTableRow> operations,
-    NoteSection notesSection
+    NoteSection notesSection,
+    List<TechJournalTableRow> resources
 ) {}

--- a/src/main/java/com/viking/field_passport_generator/model/MachineResource.java
+++ b/src/main/java/com/viking/field_passport_generator/model/MachineResource.java
@@ -1,9 +1,11 @@
 package com.viking.field_passport_generator.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.viking.field_passport_generator.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record MachineResource(
@@ -31,8 +33,10 @@ public record MachineResource(
     }
 
     public String getFullTitle() {
-        String res = unitTypeName + " " + modelName() + " " + stateNumber() + " " + inventoryNumber;
-        return res.trim().replaceAll("\\s+", " ");
+        return Stream.of(unitTypeName, modelName(), stateNumber(), inventoryNumber)
+                .map(StringUtils::clean)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.joining(" "));
     }
 }
 

--- a/src/main/java/com/viking/field_passport_generator/model/MachineResource.java
+++ b/src/main/java/com/viking/field_passport_generator/model/MachineResource.java
@@ -1,0 +1,38 @@
+package com.viking.field_passport_generator.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record MachineResource(
+        Long id,
+        String unitTypeName,
+        String model,
+        String unitModelName,
+        String number,
+        String inventoryNumber
+) {
+
+    public String modelName() {
+        return unitModelName.isBlank() ? model : unitModelName;
+    }
+
+    public String stateNumber() {
+        return Arrays.stream(number.split(" "))
+                .filter(word -> !word.isEmpty() && !word.equalsIgnoreCase(inventoryNumber))
+                .distinct()
+                .collect(Collectors.joining(" "));
+    }
+
+    public static MachineResource unknown(Long id) {
+        return new MachineResource(id, "Неизвестная техника", "", "", "", "");
+    }
+
+    public String getFullTitle() {
+        String res = unitTypeName + " " + modelName() + " " + stateNumber() + " " + inventoryNumber;
+        return res.trim().replaceAll("\\s+", " ");
+    }
+}
+

--- a/src/main/java/com/viking/field_passport_generator/model/TechJournalTableRow.java
+++ b/src/main/java/com/viking/field_passport_generator/model/TechJournalTableRow.java
@@ -1,9 +1,25 @@
 package com.viking.field_passport_generator.model;
 
+import java.util.Objects;
+
 public record TechJournalTableRow(
         MachineResource resource,
         String fieldTools,
         String driver,
         String period
 ) {
+
+    public TechJournalTableRow {
+        Objects.requireNonNull(resource, "Resource from dictionary cannot be null");
+
+        fieldTools = Objects.requireNonNullElse(fieldTools, "").trim();
+        driver = Objects.requireNonNullElse(driver, "").trim();
+        period = Objects.requireNonNullElse(period, "").trim();
+    }
+
+    public String getFullEquipmentName() {
+        return fieldTools.isEmpty()
+                ? resource.getFullTitle()
+                : resource.getFullTitle() + " — " + fieldTools;
+    }
 }

--- a/src/main/java/com/viking/field_passport_generator/model/TechJournalTableRow.java
+++ b/src/main/java/com/viking/field_passport_generator/model/TechJournalTableRow.java
@@ -1,0 +1,9 @@
+package com.viking.field_passport_generator.model;
+
+public record TechJournalTableRow(
+        MachineResource resource,
+        String fieldTools,
+        String driver,
+        String period
+) {
+}

--- a/src/main/java/com/viking/field_passport_generator/service/PdfGeneratorService.java
+++ b/src/main/java/com/viking/field_passport_generator/service/PdfGeneratorService.java
@@ -1,9 +1,6 @@
 package com.viking.field_passport_generator.service;
 
-import com.viking.field_passport_generator.model.FieldPassport;
-import com.viking.field_passport_generator.model.NoteImage;
-import com.viking.field_passport_generator.model.NoteTableRow;
-import com.viking.field_passport_generator.model.OperationTableRow;
+import com.viking.field_passport_generator.model.*;
 import com.viking.field_passport_generator.util.NoteImageComparators;
 import com.viking.field_passport_generator.util.PdfUIHelper;
 import org.openpdf.text.Document;
@@ -147,6 +144,12 @@ public class PdfGeneratorService implements PassportGeneratorService {
 
         document.newPage();
         document.add(PdfUIHelper.createPhotoGrid(writer, photoMap));
+
+        document.newPage();
+        document.add(PdfUIHelper.createSectionTitle("Раздел 7. Работающие механизаторы, техника, агрегаты."));
+        List<TechJournalTableRow> techJournalTableRows = passport.resources();
+        PdfPTable techJournalTable = PdfUIHelper.createTechJournalTable(techJournalTableRows);
+        document.add(techJournalTable);
 
         log.info("Данные поля успешно добавлены в документ");
     }

--- a/src/main/java/com/viking/field_passport_generator/util/PdfUIHelper.java
+++ b/src/main/java/com/viking/field_passport_generator/util/PdfUIHelper.java
@@ -1,8 +1,6 @@
 package com.viking.field_passport_generator.util;
 
-import com.viking.field_passport_generator.model.NoteTableRow;
-import com.viking.field_passport_generator.model.OperationTableRow;
-import com.viking.field_passport_generator.model.TmcItem;
+import com.viking.field_passport_generator.model.*;
 import org.openpdf.text.*;
 import org.openpdf.text.Font;
 import org.openpdf.text.Image;
@@ -91,7 +89,6 @@ public final class PdfUIHelper {
         table.setWidthPercentage(100f);
         table.setSpacingBefore(10f);
         table.setSpacingAfter(10f);
-        table.setKeepTogether(true);
         if (widths != null) {
             try {
                 table.setWidths(widths);
@@ -388,5 +385,26 @@ public final class PdfUIHelper {
             }
         }
         return grid;
+    }
+
+    public static PdfPTable createTechJournalTable(List<TechJournalTableRow> techJournalTableRows) {
+        if (techJournalTableRows == null || techJournalTableRows.isEmpty()) {
+            return new PdfPTable(1);
+        }
+
+        float[] columnWidths = {50f, 30f, 20f};
+        PdfPTable table = createStandardTable(3, columnWidths);
+        table.setHeaderRows(1);
+
+        for (TechJournalTableRow row : techJournalTableRows) {
+
+            String machineWithTool = row.resource().getFullTitle() + " — " + row.fieldTools();
+            table.addCell(createStyledCell(new Phrase(machineWithTool, FONT_TABLE_BODY), null, Element.ALIGN_LEFT));
+
+            table.addCell(createStyledCell(new Phrase(row.driver(), FONT_TABLE_BODY), null, Element.ALIGN_LEFT));
+
+            table.addCell(createStyledCell(new Phrase(row.period(), FONT_TABLE_BODY), null, Element.ALIGN_LEFT));
+        }
+        return table;
     }
 }

--- a/src/main/java/com/viking/field_passport_generator/util/PdfUIHelper.java
+++ b/src/main/java/com/viking/field_passport_generator/util/PdfUIHelper.java
@@ -394,11 +394,9 @@ public final class PdfUIHelper {
 
         float[] columnWidths = {50f, 30f, 20f};
         PdfPTable table = createStandardTable(3, columnWidths);
-        table.setHeaderRows(1);
 
         for (TechJournalTableRow row : techJournalTableRows) {
-
-            String machineWithTool = row.resource().getFullTitle() + " — " + row.fieldTools();
+            String machineWithTool = row.getFullEquipmentName();
             table.addCell(createStyledCell(new Phrase(machineWithTool, FONT_TABLE_BODY), null, Element.ALIGN_LEFT));
 
             table.addCell(createStyledCell(new Phrase(row.driver(), FONT_TABLE_BODY), null, Element.ALIGN_LEFT));

--- a/src/main/java/com/viking/field_passport_generator/util/ResourceReader.java
+++ b/src/main/java/com/viking/field_passport_generator/util/ResourceReader.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 
 public final class ResourceReader {
 
-    private ResourceReader() {/* Utility class */}
+    private ResourceReader() { throw new UnsupportedOperationException("Utility class"); }
 
     @SuppressWarnings("resource")
     public static InputStream readAsStream(String path) {

--- a/src/main/java/com/viking/field_passport_generator/util/StringUtils.java
+++ b/src/main/java/com/viking/field_passport_generator/util/StringUtils.java
@@ -7,7 +7,7 @@ public final class StringUtils {
         if (s == null || s.isBlank() || s.equalsIgnoreCase("null")) {
             return "";
         }
-        return s.trim().replaceAll("//s+", " ");
+        return s.trim().replaceAll("\\s+", " ");
     }
 
     public static String normalize(String s, String fallback) {

--- a/src/main/java/com/viking/field_passport_generator/util/StringUtils.java
+++ b/src/main/java/com/viking/field_passport_generator/util/StringUtils.java
@@ -1,0 +1,17 @@
+package com.viking.field_passport_generator.util;
+
+public final class StringUtils {
+    private StringUtils() { throw new UnsupportedOperationException("Utility class"); }
+
+    public static String clean(String s) {
+        if (s == null || s.isBlank() || s.equalsIgnoreCase("null")) {
+            return "";
+        }
+        return s.trim().replaceAll("//s+", " ");
+    }
+
+    public static String normalize(String s, String fallback) {
+        String cleaned = clean(s);
+        return cleaned.isEmpty() ? fallback : cleaned;
+    }
+}

--- a/src/main/java/com/viking/field_passport_generator/util/YearUtils.java
+++ b/src/main/java/com/viking/field_passport_generator/util/YearUtils.java
@@ -6,9 +6,16 @@ import java.util.regex.Pattern;
 public class YearUtils {
     private static final Pattern YEAR_PATTERN = Pattern.compile("(\\d{4})");
 
-    public static String extractYear(String text) {
-        if (text == null || text.isBlank()) return "";
+    public static int extractYear(String text) {
+        if (text == null || text.isBlank()) return -1;
         Matcher matcher = YEAR_PATTERN.matcher(text);
-        return matcher.find() ? matcher.group(1) : "";
+        if (matcher.find()) {
+            try {
+                return Integer.parseInt(matcher.group(1));
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        return -1;
     }
 }


### PR DESCRIPTION
Closes #12

***Overview***
This commit introduces a major overhaul of the data processing pipeline to resolve inconsistencies caused by using field names as keys.

***Core Changes:***
- [Aggregator] Switched grouping logic from 'fieldName' to 'fieldId'. Centralized data preparation to serve both Operation and TechJournal mappers.
- [Mapper] Updated TechJournal and Operation mappers to consume ID-grouped data.
- [Model] Added 'fieldId' support to domain models for better traceability.

***New Features:***
- [PDF] Implemented Section 7 (Working operators, Machinery and Aggregates).