### PR TITLE
feat: implement chart generation (section 4)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
         <openpdf.version>3.0.0</openpdf.version>
         <jackson-dataformat-yaml.version>2.21.2</jackson-dataformat-yaml.version>
         <jsoup.version>1.22.1</jsoup.version>
+        <xchart.version>3.8.8</xchart.version>
     </properties>
 
     <dependencyManagement>
@@ -119,6 +120,13 @@
             <version>5.23.0</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.knowm.xchart</groupId>
+            <artifactId>xchart</artifactId>
+            <version>${xchart.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/src/main/java/com/viking/field_passport_generator/Main.java
+++ b/src/main/java/com/viking/field_passport_generator/Main.java
@@ -20,8 +20,7 @@ public class Main {
         AppConfig appConfig = new AppConfig();
         AppContainer container = new AppContainer(appConfig);
         log.info("Application Started.");
-        container.getSyncService().warmUpNotes("data/notesData.json");
-        container.getSyncService().warmUpSatelliteMetadata("data/fieldData.json");
+        container.getSyncService().warmUpAll("data/notesData.json", "data/fieldData.json");
 
         runMenu(container.getDataProvider(), container.getPassportGeneratorService(), container.getSyncService());
     }
@@ -61,8 +60,7 @@ public class Main {
                                     ImageSyncService syncService) {
         log.info("Загрузка данных для массовой генерации...");
         List<FieldPassport> all = provider.getPassportsData();
-        syncService.prepareNoteImages(all);
-        syncService.prepareSatelliteImages(all);
+        syncService.prepareAll(all);
         service.generateAll(all);
     }
 
@@ -80,8 +78,7 @@ public class Main {
             System.out.println("❌ Поле '" + target + "' не найдено в базе данных.");
         } else {
             log.info("Найдено сезонов для поля {}: {}. Начинаю генерацию...", target, selected.size());
-            syncService.prepareNoteImages(selected);
-            syncService.prepareSatelliteImages(selected);
+            syncService.prepareAll(selected);
             service.generateAll(selected); // Генерируем PDF для каждого найденного сезона
             System.out.println("✅ Паспорта для поля " + target + " успешно созданы.");
         }

--- a/src/main/java/com/viking/field_passport_generator/config/AppConfig.java
+++ b/src/main/java/com/viking/field_passport_generator/config/AppConfig.java
@@ -12,6 +12,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.DateTimeException;
+import java.time.ZoneId;
 import java.util.*;
 
 public class AppConfig {
@@ -103,6 +105,11 @@ public class AppConfig {
         return val != null ? Boolean.parseBoolean(val.trim()) : defaultValue;
     }
 
+    public Path getPath(String key, String defaultValue) {
+        String val = getString(key, defaultValue);
+        return Path.of(val);
+    }
+
     public Set<SpectralIndex> getSpectralIndex(String key, Set<SpectralIndex> defaultValue) {
         JsonNode node = findNode(key);
 
@@ -141,13 +148,48 @@ public class AppConfig {
         return node.isNumber() ? node.asDouble() : defaultValue;
     }
 
+    public ZoneId getTimezone(String key, ZoneId defaultValue) {
+        JsonNode node = findNode(key);
+        if (!node.isMissingNode() && node.isTextual() && !node.asText().isBlank()) {
+            try {
+                return ZoneId.of(node.asText());
+            } catch (DateTimeException e) {
+                log.warn("Invalid timezone in config {}: {}", key, node.asText());
+            }
+        }
+        return defaultValue;
+    }
+
     public SatelliteConfig getSatelliteConfig() {
         return new SatelliteConfig(
+                getPath("agro.cache-dir", "cache/images"),
                 getString("agro.satellite.fromDate", "20240101"),
-                getString("agro.satellite.toDate"),
+                getString("agro.satellite.toDate", "20260101"),
                 getInt("agro.satellite.scan-window-days", 7),
                 getDouble("agro.satellite.cloud-threshold", 0.8),
-                getDouble("agro.satellite.cloud-weight-factor", 5.0)
+                getDouble("agro.satellite.cloud-weight-factor", 5.0),
+                getString("agro.satellite-extension", "png")
+        );
+    }
+
+    public NoteConfig getNoteConfig() {
+        return new NoteConfig(
+            getString("app.notes-dir", "notes"),
+            getString("app.notes-extension", "jpg"),
+            getPath("app.cache-dir", "cache/images")
+        );
+    }
+
+    public ChartConfig getChartConfig() {
+        return new ChartConfig(
+                getString("app.cache.charts.dir", "charts"),
+                getString("app.cache.charts.default-extension", "png"),
+                getString("app.cache.charts.file-prefix", "chart_"),
+                getInt("app.cache.charts.width", 800),
+                getInt("app.cache.charts.height", 400),
+                getPath("app.cache.path", "cache/images"),
+                getString("app.cache.charts.font-path", "fonts/NotoSans-Regular.ttf"),
+                getTimezone("app.timezone", ZoneId.of("Asia/Krasnoyarsk"))
         );
     }
 }

--- a/src/main/java/com/viking/field_passport_generator/config/AppConfig.java
+++ b/src/main/java/com/viking/field_passport_generator/config/AppConfig.java
@@ -189,7 +189,8 @@ public class AppConfig {
                 getInt("app.cache.charts.height", 400),
                 getPath("app.cache.path", "cache/images"),
                 getString("app.cache.charts.font-path", "fonts/NotoSans-Regular.ttf"),
-                getTimezone("app.timezone", ZoneId.of("Asia/Krasnoyarsk"))
+                getTimezone("app.timezone", ZoneId.of("Asia/Krasnoyarsk")),
+                getDouble("agro.satellite.cloud-threshold", 0.8)
         );
     }
 }

--- a/src/main/java/com/viking/field_passport_generator/config/AppContainer.java
+++ b/src/main/java/com/viking/field_passport_generator/config/AppContainer.java
@@ -7,17 +7,12 @@ import com.viking.field_passport_generator.data.provider.FileDataProvider;
 import com.viking.field_passport_generator.http.InternalHttpClient;
 import com.viking.field_passport_generator.http.NoteImageLoader;
 import com.viking.field_passport_generator.http.SatelliteImageLoader;
+import com.viking.field_passport_generator.http.strategy.ChartStrategy;
 import com.viking.field_passport_generator.http.strategy.NoteStrategy;
 import com.viking.field_passport_generator.http.strategy.SatelliteStrategy;
-import com.viking.field_passport_generator.mapper.NoteMapper;
-import com.viking.field_passport_generator.mapper.OperationMapper;
-import com.viking.field_passport_generator.mapper.SatelliteMapper;
-import com.viking.field_passport_generator.mapper.TechJournalMapper;
+import com.viking.field_passport_generator.mapper.*;
 import com.viking.field_passport_generator.model.SpectralIndex;
-import com.viking.field_passport_generator.service.ImageCacheService;
-import com.viking.field_passport_generator.service.ImageSyncService;
-import com.viking.field_passport_generator.service.PassportGeneratorService;
-import com.viking.field_passport_generator.service.PdfGeneratorService;
+import com.viking.field_passport_generator.service.*;
 import com.viking.field_passport_generator.util.JsonDataParser;
 
 import java.nio.file.Path;
@@ -27,79 +22,110 @@ import java.util.List;
 import java.util.Set;
 
 public class AppContainer {
-    // Services ready for operation (getters provided below)
     private final DataProvider dataProvider;
     private final PassportGeneratorService passportGeneratorService;
     private final ImageSyncService syncService;
 
     public AppContainer(AppConfig config) {
-        // --- 1. Infrastructure Setup ---
-        // Initialize common utilities used across different services
+        // ===== 1. Utilities =====
         JsonDataParser jsonParser = new JsonDataParser();
-        long recoveryTime = config.getLong("agro.api.recovery-time-ms", 60_000L);
-        long minDownloadSize = config.getLong("agro.api.min-downlad-size-bytes", 1024L);
+        Path cacheDir = Path.of(config.getString("app.cache-dir", "cache/images"));
 
-        int notesLimit = config.getInt("agro.api.satellite.max-concurrent-request", 10);
-        InternalHttpClient noteClient = new InternalHttpClient(notesLimit, recoveryTime, minDownloadSize);
+        // ===== 2. HTTP Clients =====
+        InternalHttpClient noteClient = createNoteHttpClient(config);
+        InternalHttpClient satelliteClient = createSatelliteHttpClient(config);
 
-        int satelliteLimit = config.getInt("agro.api.notes.max-concurrent-request", 5);
-        InternalHttpClient satelliteClient = new InternalHttpClient(satelliteLimit, recoveryTime, minDownloadSize);
+        // ===== 3. Image Loading Strategies =====
+        NoteStrategy noteStrategy = createNoteStrategy(config, noteClient);
+        SatelliteStrategy satelliteStrategy = createSatelliteStrategy(config, satelliteClient, jsonParser);
+        ChartStrategy chartStrategy = createChartStrategy(config, jsonParser);
 
-        // --- 2. Image Processing Layer ---
-        // Configure image loading, caching, and synchronization
-        NoteImageLoader noteImageLoader = new NoteImageLoader(
-                noteClient,
+        // ===== 4. Cache & Sync =====
+        ImageCacheService imageCache = new ImageCacheService(cacheDir, List.of(noteStrategy, satelliteStrategy, chartStrategy));
+        this.syncService = new ImageSyncService(imageCache, jsonParser);
+
+        // ===== 5. Data Aggregation =====
+        FieldDataAggregator aggregator = createAggregator(config);
+        this.dataProvider = new FileDataProvider(jsonParser, aggregator);
+
+        // ===== 6. PDF Generation =====
+        this.passportGeneratorService = createPdfService(config);
+    }
+
+    // ========== Factory Methods ==========
+
+    private InternalHttpClient createNoteHttpClient(AppConfig config) {
+        return new InternalHttpClient(
+                config.getInt("agro.api.notes.max-concurrent-request", 10),
+                config.getLong("agro.api.recovery-time-ms", 60_000L),
+                config.getLong("agro.api.min-download-size-bytes", 1024L)
+        );
+    }
+
+    private InternalHttpClient createSatelliteHttpClient(AppConfig config) {
+        return new InternalHttpClient(
+                config.getInt("agro.api.satellite.max-concurrent-request", 5),
+                config.getLong("agro.api.recovery-time-ms", 60_000L),
+                config.getLong("agro.api.min-download-size-bytes", 1024L)
+        );
+    }
+
+    private NoteStrategy createNoteStrategy(AppConfig config, InternalHttpClient client) {
+        NoteConfig noteConfig = config.getNoteConfig();
+        NoteImageLoader loader = new NoteImageLoader(
+                client,
                 config.getString("agro.api.base-url"),
                 config.getString("agro.api.key"),
                 config.getString("agro.api.user-agent"),
                 config.getString("agro.api.endpoints.attachments-info")
         );
+        return new NoteStrategy(loader, noteConfig);
+    }
 
-        SatelliteImageLoader satelliteLoader = new SatelliteImageLoader(
-                satelliteClient,
+    private SatelliteStrategy createSatelliteStrategy(AppConfig config, InternalHttpClient client,
+                                                      JsonDataParser jsonParser) {
+        SatelliteConfig satelliteConfig = config.getSatelliteConfig();
+        SatelliteImageLoader loader = new SatelliteImageLoader(
+                client,
                 config.getString("agro.api.base-url"),
                 config.getString("agro.api.key"),
                 config.getString("agro.api.user-agent"),
                 config.getString("agro.api.endpoints.spectral-indices")
         );
+        return new SatelliteStrategy(loader, jsonParser, satelliteConfig);
+    }
 
-        Path cacheDir = Path.of(config.getString("app.cache-dir", "cache"));
-        NoteStrategy noteStrategy = new NoteStrategy(noteImageLoader, cacheDir);
-        SatelliteStrategy satelliteStrategy = new SatelliteStrategy(satelliteLoader, jsonParser, cacheDir, config.getSatelliteConfig());
-        ImageCacheService imageCache = new ImageCacheService(cacheDir, List.of(noteStrategy, satelliteStrategy));
-        this.syncService = new ImageSyncService(imageCache, jsonParser);
+    private ChartStrategy createChartStrategy(AppConfig config, JsonDataParser jsonParser) {
+        ChartConfig chartConfig = config.getChartConfig();
+        ChartGenerator chartGenerator = new XChartGeneratorImpl(chartConfig);
+        double cloudThreshold = config.getDouble("app.satellite.cloud-threshold", 0.8);
+        ZoneId timezone = ZoneId.of(config.getString("app.timezone", "Asia/Krasnoyarsk"));
+        ChartMapper chartMapper = new ChartMapper(cloudThreshold);
+        return new ChartStrategy(chartGenerator, chartConfig, jsonParser, chartMapper, timezone);
+    }
 
-        // --- 3. Data Processing Layer (Mappers & Aggregators) ---
-        // Convert raw configuration strings into typed domain objects
+    private FieldDataAggregator createAggregator(AppConfig config) {
         ZoneId timezone = ZoneId.of(config.getString("app.timezone", "Asia/Krasnoyarsk"));
         Duration threshold = Duration.ofHours(config.getInt("app.threshold-hours", 48));
 
         OperationMapper opMapper = new OperationMapper(timezone, threshold);
         NoteMapper noteMapper = new NoteMapper(timezone);
         TechJournalMapper techMapper = new TechJournalMapper(config.getString("app.default-empty-label", "—"));
+
         Set<SpectralIndex> requiredIndices = config.getSpectralIndex("agro.satellite.indices", Set.of(SpectralIndex.NDVI));
         List<SatelliteCaptureRule> captureRules = config.getMappingResult("agro.satellite.mapping");
         SatelliteMapper satelliteMapper = new SatelliteMapper(requiredIndices, captureRules);
-        FieldDataAggregator aggregator = new FieldDataAggregator(opMapper, noteMapper, techMapper, satelliteMapper,
-                timezone);
 
-        // DataProvider handles the retrieval and aggregation of field data
-        this.dataProvider = new FileDataProvider(jsonParser, aggregator);
-
-        // --- 4. PDF Generation Layer ---
-        // Prepare storage paths and safety thresholds for document generation
-        Path outputDir = Path.of(config.getString("app.storage.output-dir", "output"));
-
-        // Convert Megabytes from config to Bytes for internal safety checks
-        long minSpaceBytes = (long) config.getInt("app.min-free-space-mb", 1024) * 1024L * 1024L;
-
-        this.passportGeneratorService = new PdfGeneratorService(
-                minSpaceBytes,
-                outputDir
-        );
+        return new FieldDataAggregator(opMapper, noteMapper, techMapper, satelliteMapper, timezone);
     }
 
-    // Getters for Main entry point
+    private PassportGeneratorService createPdfService(AppConfig config) {
+        Path outputDir = Path.of(config.getString("app.storage.output-dir", "output"));
+        long minSpaceBytes = (long) config.getInt("app.min-free-space-mb", 1024) * 1024L * 1024L;
+        return new PdfGeneratorService(minSpaceBytes, outputDir);
+    }
+
+    // ========== Getters ==========
     public DataProvider getDataProvider() { return dataProvider; }
     public PassportGeneratorService getPassportGeneratorService() { return passportGeneratorService; }
     public ImageSyncService getSyncService() { return syncService; }

--- a/src/main/java/com/viking/field_passport_generator/config/AppContainer.java
+++ b/src/main/java/com/viking/field_passport_generator/config/AppContainer.java
@@ -98,8 +98,8 @@ public class AppContainer {
     private ChartStrategy createChartStrategy(AppConfig config, JsonDataParser jsonParser) {
         ChartConfig chartConfig = config.getChartConfig();
         ChartGenerator chartGenerator = new XChartGeneratorImpl(chartConfig);
-        double cloudThreshold = config.getDouble("app.satellite.cloud-threshold", 0.8);
-        ZoneId timezone = ZoneId.of(config.getString("app.timezone", "Asia/Krasnoyarsk"));
+        double cloudThreshold = chartConfig.cloudThreshold();
+        ZoneId timezone = chartConfig.timezone();
         ChartMapper chartMapper = new ChartMapper(cloudThreshold);
         return new ChartStrategy(chartGenerator, chartConfig, jsonParser, chartMapper, timezone);
     }

--- a/src/main/java/com/viking/field_passport_generator/config/ChartConfig.java
+++ b/src/main/java/com/viking/field_passport_generator/config/ChartConfig.java
@@ -1,0 +1,16 @@
+package com.viking.field_passport_generator.config;
+
+import java.nio.file.Path;
+import java.time.ZoneId;
+
+public record ChartConfig(
+        String dir,
+        String extension,
+        String filePrefix,
+        int width,
+        int height,
+        Path cachePath,
+        String fontPath,
+        ZoneId timezone
+) {
+}

--- a/src/main/java/com/viking/field_passport_generator/config/ChartConfig.java
+++ b/src/main/java/com/viking/field_passport_generator/config/ChartConfig.java
@@ -11,6 +11,7 @@ public record ChartConfig(
         int height,
         Path cachePath,
         String fontPath,
-        ZoneId timezone
+        ZoneId timezone,
+        Double cloudThreshold
 ) {
 }

--- a/src/main/java/com/viking/field_passport_generator/config/NoteConfig.java
+++ b/src/main/java/com/viking/field_passport_generator/config/NoteConfig.java
@@ -1,0 +1,10 @@
+package com.viking.field_passport_generator.config;
+
+import java.nio.file.Path;
+
+public record NoteConfig(
+        String dir,
+        String extension,
+        Path cachePath
+) {
+}

--- a/src/main/java/com/viking/field_passport_generator/config/SatelliteConfig.java
+++ b/src/main/java/com/viking/field_passport_generator/config/SatelliteConfig.java
@@ -2,12 +2,15 @@ package com.viking.field_passport_generator.config;
 
 import com.viking.field_passport_generator.data.dto.satellite.SatelliteCaptureRule;
 
+import java.nio.file.Path;
 import java.util.List;
 
 public record SatelliteConfig(
+        Path cachePath,
         String fromDate,
         String toDate,
         int scanWindowDays,
         double maxCloudThreshold,
-        double cloudWeightFactor
+        double cloudWeightFactor,
+        String extension
 ) {}

--- a/src/main/java/com/viking/field_passport_generator/data/aggregator/FieldDataAggregator.java
+++ b/src/main/java/com/viking/field_passport_generator/data/aggregator/FieldDataAggregator.java
@@ -5,6 +5,7 @@ import com.viking.field_passport_generator.data.dictionary.TmcDictionary;
 import com.viking.field_passport_generator.data.dto.*;
 import com.viking.field_passport_generator.mapper.*;
 import com.viking.field_passport_generator.model.*;
+import com.viking.field_passport_generator.model.note.NoteSection;
 import com.viking.field_passport_generator.util.YearUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,12 +82,21 @@ public class FieldDataAggregator {
         List<RawNote> fieldNotes = notesByFieldId.getOrDefault(fieldId, Collections.emptyList());
         List<OperationTableRow> operationTableRows = operationMapper.mapToTableRow(cleanOps, tmcDictionary);
         NoteSection noteSection = noteMapper.map(fieldNotes, String.valueOf(passportYear));
-        List<TechJournalTableRow> techJournalTableRows = techJournalMapper.mapToTableRow(cleanOps, machineDictionary);
         List<SatelliteImage> satelliteImages = satelliteMapper.map(fieldId, operationTableRows);
-
         satelliteImages.sort(Comparator.comparing(SatelliteImage::getPlanDate));
-        return PassportMapper.mapToDomain(rawField, operationTableRows, noteSection, techJournalTableRows,
-                satelliteImages);
+        List<TechJournalTableRow> techJournalTableRows = techJournalMapper.mapToTableRow(cleanOps, machineDictionary);
+
+        String chartTitle = String.format("%s - %s %d", rawField.field(), rawField.department(), passportYear);
+        ChartImage indexChart = new ChartImage(String.valueOf(fieldId), passportYear, chartTitle, new ArrayList<>());
+
+        return PassportMapper.mapToDomain(
+                rawField,
+                operationTableRows,
+                noteSection,
+                satelliteImages,
+                indexChart,
+                techJournalTableRows
+                );
     }
 
     private List<RawOperationData> filterOperationsByYear(List<RawOperationData> ops, int targetYear) {

--- a/src/main/java/com/viking/field_passport_generator/data/dto/chart/ChartPoint.java
+++ b/src/main/java/com/viking/field_passport_generator/data/dto/chart/ChartPoint.java
@@ -1,0 +1,19 @@
+package com.viking.field_passport_generator.data.dto.chart;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
+
+public record ChartPoint(
+        LocalDate date,
+        double ndviMean,
+        double ndviMin,
+        double ndviMax,
+        double ndwiMean,
+        double msiMean,
+        double gliMean
+) {
+    public Date toDate(ZoneId timezone) {
+        return java.util.Date.from(date.atStartOfDay(timezone).toInstant());
+    }
+}

--- a/src/main/java/com/viking/field_passport_generator/http/strategy/ChartStrategy.java
+++ b/src/main/java/com/viking/field_passport_generator/http/strategy/ChartStrategy.java
@@ -58,7 +58,6 @@ public class ChartStrategy implements ImageProviderStrategy {
             String id = chart.getId();
             String fileName = filePrefix + id + "_" + chart.getYear();
             Path localPath = resolvePath(cachePath,fileName + ".*", fileName + "." + defaultExt, id, subDir);
-            System.out.println(">>> localPath = " + localPath.toAbsolutePath());
             readFromDisk(localPath).or(() -> {
                 log.info("Cache is empty, preparing data for chart: {}. Path: {}", chart.getTitle(), localPath);
 
@@ -83,7 +82,7 @@ public class ChartStrategy implements ImageProviderStrategy {
                         });
             }).ifPresent(chart::setImageBytes);
         } catch (Exception e) {
-            log.error("Ошибка та самая: ", e);
+            log.error("Failed to process chart : {}", e.getMessage());
         }
 
     }

--- a/src/main/java/com/viking/field_passport_generator/http/strategy/ChartStrategy.java
+++ b/src/main/java/com/viking/field_passport_generator/http/strategy/ChartStrategy.java
@@ -1,0 +1,95 @@
+package com.viking.field_passport_generator.http.strategy;
+
+import com.viking.field_passport_generator.config.ChartConfig;
+import com.viking.field_passport_generator.data.dto.satellite.FieldSpectralResponse;
+import com.viking.field_passport_generator.mapper.ChartMapper;
+import com.viking.field_passport_generator.model.ChartImage;
+import com.viking.field_passport_generator.model.ImageSource;
+import com.viking.field_passport_generator.model.SourceType;
+import com.viking.field_passport_generator.service.ChartGenerator;
+import com.viking.field_passport_generator.util.JsonDataParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.time.ZoneId;
+import java.util.Optional;
+import java.util.Set;
+
+public class ChartStrategy implements ImageProviderStrategy {
+    private static final Logger log = LoggerFactory.getLogger(ChartStrategy.class);
+
+    private final ChartGenerator chartGenerator;
+    private final JsonDataParser jsonParser;
+    private final ChartMapper chartMapper;
+    private final Path cachePath;
+    private final String subDir;
+    private final String defaultExt;
+    private final String filePrefix;
+    private final ZoneId timezone;
+
+    public ChartStrategy(ChartGenerator chartGenerator, ChartConfig config, JsonDataParser jsonParser,
+                         ChartMapper chartMapper, ZoneId timezone) {
+        this.chartGenerator = chartGenerator;
+        this.cachePath = config.cachePath();
+        this.subDir = config.dir();
+        this.defaultExt = config.extension();
+        this.filePrefix = config.filePrefix();
+        this.jsonParser = jsonParser;
+        this.chartMapper = chartMapper;
+        this.timezone = timezone;
+    }
+
+    @Override
+    public Logger getLogger() {
+        return log;
+    }
+
+    @Override
+    public void synchronize(Set<String> ids) {
+        log.info("Charts are generated on demand from local satellite metadata");
+    }
+
+    @Override
+    public void process(ImageSource source) {
+        try {
+            if (!(source instanceof ChartImage chart) || chart.hasImage()) { return; }
+
+            String id = chart.getId();
+            String fileName = filePrefix + id + "_" + chart.getYear();
+            Path localPath = resolvePath(cachePath,fileName + ".*", fileName + "." + defaultExt, id, subDir);
+            System.out.println(">>> localPath = " + localPath.toAbsolutePath());
+            readFromDisk(localPath).or(() -> {
+                log.info("Cache is empty, preparing data for chart: {}. Path: {}", chart.getTitle(), localPath);
+
+                // 1. Пытаемся прочитать историю прямо здесь, когда это реально нужно
+                Path historyFile = cachePath.resolve(id).resolve("history.json");
+
+                return Optional.ofNullable(jsonParser.parse(historyFile, FieldSpectralResponse.class))
+                        .map(FieldSpectralResponse::data)
+                        .map(chartMapper::toChartPoints)
+                        .map(points -> points.stream()
+                                .filter(p ->  p.date().getYear() == chart.getYear())
+                                .toList())
+                        .filter(filteredPoints -> !filteredPoints.isEmpty())
+                        .flatMap(filteredPoints -> {
+                            // 2. Наполняем объект точками перед генерацией
+                            chart.setPoints(filteredPoints);
+                            return chartGenerator.generateCombinedChart(chart);
+                        })
+                        .map(bytes -> {
+                            writeToDisk(localPath, bytes);
+                            return bytes;
+                        });
+            }).ifPresent(chart::setImageBytes);
+        } catch (Exception e) {
+            log.error("Ошибка та самая: ", e);
+        }
+
+    }
+
+    @Override
+    public SourceType getType() {
+        return SourceType.CHART;
+    }
+}

--- a/src/main/java/com/viking/field_passport_generator/http/strategy/ImageProviderStrategy.java
+++ b/src/main/java/com/viking/field_passport_generator/http/strategy/ImageProviderStrategy.java
@@ -3,8 +3,12 @@ package com.viking.field_passport_generator.http.strategy;
 import com.viking.field_passport_generator.model.ImageSource;
 import com.viking.field_passport_generator.model.SourceType;
 
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
+import java.util.Iterator;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -12,6 +16,7 @@ import java.util.Set;
  * It encapsulates the logic for both "Eager" (Notes) and "Lazy" (Satellite) loading.
  */
 public interface ImageProviderStrategy {
+    org.slf4j.Logger getLogger();
     /**
      * Performs preliminary data preparation.
      * For notes: triggers a bulk download of all images in batches of 50.
@@ -24,16 +29,51 @@ public interface ImageProviderStrategy {
 
     void process(ImageSource source);
 
-    /**
-     * Resolves the local file system path for the given resource.
-     *
-     * @param root the root directory of the cache.
-     * @param id the identifier of the entity
-     * @param params implementation-specific parameters used to construct the file path.
-     * @return the resolved Path to the file.
-     */
-    Path resolvePath(Path root, String id, Map<String, String> params);
-
     SourceType getType();
+
+    default Path resolvePath(Path root, String fileNamePattern, String defaultName, String... subDirs) {
+        Path targetDir = root;
+        for (String sub : subDirs) {
+            targetDir = targetDir.resolve(sub);
+        }
+        if (Files.isDirectory(targetDir)) {
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(targetDir, fileNamePattern)) {
+                Iterator<Path> iterator = stream.iterator();
+                if (iterator.hasNext()) {
+                    return iterator.next();
+                }
+            } catch (IOException e) {
+                getLogger().error("Error scanning cache directory {}: {}", targetDir, e.getMessage());
+            }
+        }
+        Path defaultPath = targetDir.resolve(defaultName);
+        getLogger().debug("Cache miss. Default path: {}", defaultPath);
+        return defaultPath;
+    }
+
+    default void writeToDisk(Path targetPath, byte[] data) {
+        if (data == null || data.length == 0) {
+            getLogger().warn("Attempted to save empty data to: {}", targetPath);
+            return;
+        }
+        try {
+            Files.createDirectories(targetPath.getParent());
+            Files.write(targetPath, data);
+            getLogger().info("Successfully saved: {}", targetPath.getFileName());
+        } catch (IOException e) {
+            getLogger().error("Critical I/O error while saving {}: {}", targetPath, e.getMessage());
+        }
+    }
+
+    default Optional<byte[]> readFromDisk(Path path) {
+        try {
+            if (path != null && Files.exists(path)) {
+                return Optional.of(Files.readAllBytes(path));
+            }
+        } catch (IOException e) {
+            getLogger().error("Error reading file {}: {}", path, e.getMessage());
+        }
+        return Optional.empty();
+    }
 }
 

--- a/src/main/java/com/viking/field_passport_generator/http/strategy/NoteStrategy.java
+++ b/src/main/java/com/viking/field_passport_generator/http/strategy/NoteStrategy.java
@@ -1,20 +1,19 @@
 package com.viking.field_passport_generator.http.strategy;
 
+import com.viking.field_passport_generator.config.NoteConfig;
 import com.viking.field_passport_generator.http.LoadResult;
 import com.viking.field_passport_generator.http.NoteImageLoader;
 import com.viking.field_passport_generator.model.ImageSource;
-import com.viking.field_passport_generator.model.NoteImage;
+import com.viking.field_passport_generator.model.note.NoteImage;
 import com.viking.field_passport_generator.model.SourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
-import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -23,10 +22,19 @@ public class NoteStrategy implements ImageProviderStrategy {
     private static final Logger log = LoggerFactory.getLogger(NoteStrategy.class);
     private final NoteImageLoader loader;
     private final Path cachePath;
+    private final String subDir;
+    private final String defaultExt;
 
-    public NoteStrategy(NoteImageLoader loader, Path cachePath) {
+    public NoteStrategy(NoteImageLoader loader, NoteConfig config) {
         this.loader = loader;
-        this.cachePath = cachePath;
+        this.cachePath = config.cachePath();
+        this.subDir = config.dir();
+        this.defaultExt = config.extension();
+    }
+
+    @Override
+    public Logger getLogger() {
+        return log;
     }
 
     @Override
@@ -36,7 +44,6 @@ public class NoteStrategy implements ImageProviderStrategy {
 
         Set<String> existingIds = getExistingCacheIds();
         List<String> toFetch = ids.stream()
-                .map(String::valueOf)
                 .filter(id -> !existingIds.contains(id))
                 .toList();
 
@@ -60,12 +67,8 @@ public class NoteStrategy implements ImageProviderStrategy {
 
             // 3. Сохраняем то, что скачалось
             result.images().forEach((id, resource) -> {
-                try {
-                    Path target = cachePath.resolve(id + "." + resource.extension());
-                    Files.write(target, resource.data());
-                } catch (IOException e) {
-                    log.error("Error recording file on disk {}: {}", id, e.getMessage());
-                }
+                Path target = resolvePath(cachePath, id +".*", id + "." + defaultExt, subDir);
+                writeToDisk(target, resource.data());
             });
 
             totalLinksFound += result.linksFound();
@@ -82,77 +85,18 @@ public class NoteStrategy implements ImageProviderStrategy {
 
         String id = note.getId();
 
-        Path localPath = findOnDisk(id);
-
-        byte[] data = null;
-        if (localPath != null && Files.exists(localPath)) {
-            data = readFromDisk(localPath);
-        } else {
-            var result = loader.load(List.of(id));
-
-            if (result.images().containsKey(id)) {
-                var resource = result.images().get(id);
-                data = resource.data();
-
-                Path targetPath = cachePath.resolve(id + "." + resource.extension());
-                saveToDisk(targetPath, data);
-            }
-        }
-
-        if (data != null) {
-            note.setImageBytes(data);
-        }
-    }
-
-    @Override
-    public Path resolvePath(Path root, String id, Map<String, String> params) {
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(root, id + ".*")) {
-            Iterator<Path> iterator = stream.iterator();
-            if (iterator.hasNext()) {
-                return iterator.next();
-            }
-        } catch (IOException e) {
-            log.error("Error searching for note image {}: {}", id, e.getMessage());
-        }
-
-        // Если файла нет, возвращаем путь по умолчанию для сохранения
-        String ext = params.getOrDefault("extension", "png");
-        return root.resolve(id + "." + ext);
+        Path localPath = resolvePath(cachePath, id + ".*", id + "." + defaultExt, subDir);
+        readFromDisk(localPath).or(() -> Optional.ofNullable(loader.load(List.of(id)).images().get(id))
+                    .map(resource -> {
+                        byte[] data = resource.data();
+                        writeToDisk(localPath, data);
+                        return data;
+                    })).ifPresent(note::setImageBytes);
     }
 
     @Override
     public SourceType getType() {
         return SourceType.NOTE;
-    }
-
-    private Path findOnDisk(String id) {
-        if (!Files.isDirectory(cachePath)) {
-            return null;
-        }
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(cachePath, id + ".*")) {
-            Iterator<Path> iterator = stream.iterator();
-            return iterator.hasNext() ? iterator.next() : null;
-        } catch (IOException e) {
-            return null;
-        }
-    }
-
-    private byte[] readFromDisk(Path path) {
-        try {
-            return Files.readAllBytes(path);
-        } catch (IOException e) {
-            log.error("Error reading note from disk {}: {}", path, e.getMessage());
-            return null;
-        }
-    }
-
-    private void saveToDisk(Path path, byte[] data) {
-        try {
-            Files.createDirectories(path.getParent());
-            Files.write(path, data);
-        } catch (IOException e) {
-            log.error("Error saving note to disk {}: {}", path, e.getMessage());
-        }
     }
 
     private void printCacheReport(int totalMissing, int totalLinksFound, int totalDownloaded, int totalFailed) {
@@ -169,8 +113,9 @@ public class NoteStrategy implements ImageProviderStrategy {
     }
 
     private Set<String> getExistingCacheIds() {
-        if (!Files.exists(cachePath)) return Set.of();
-        try (Stream<Path> stream = Files.list(cachePath)) {
+        Path notesPath = cachePath.resolve(subDir);
+        if (!Files.exists(notesPath)) return Set.of();
+        try (Stream<Path> stream = Files.list(notesPath)) {
             return stream
                     .map(path -> path.getFileName().toString())
                     .map(name -> name.contains(".") ? name.substring(0, name.lastIndexOf('.')) : name)

--- a/src/main/java/com/viking/field_passport_generator/http/strategy/SatelliteStrategy.java
+++ b/src/main/java/com/viking/field_passport_generator/http/strategy/SatelliteStrategy.java
@@ -7,11 +7,10 @@ import com.viking.field_passport_generator.http.SatelliteImageLoader;
 import com.viking.field_passport_generator.model.ImageSource;
 import com.viking.field_passport_generator.model.SatelliteImage;
 import com.viking.field_passport_generator.model.SourceType;
+import com.viking.field_passport_generator.util.ImageUtils;
 import com.viking.field_passport_generator.util.JsonDataParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -33,14 +32,29 @@ public class SatelliteStrategy implements ImageProviderStrategy {
     private final SatelliteImageLoader loader;
     private final JsonDataParser jsonParser;
     private final Path cachePath;
-    private final SatelliteConfig config;
+    private final String fromDate;
+    private final String toDate;
+    private final int scanWindowDays;
+    private final double maxCloudThreshold;
+    private final double cloudWeightFactor;
+    private final String defaultExt;
 
-    public SatelliteStrategy(SatelliteImageLoader loader, JsonDataParser jsonParser, Path cachePath,
+    public SatelliteStrategy(SatelliteImageLoader loader, JsonDataParser jsonParser,
                              SatelliteConfig config) {
         this.loader = loader;
         this.jsonParser = jsonParser;
-        this.cachePath = cachePath;
-        this.config = config;
+        this.cachePath = config.cachePath();
+        this.fromDate = config.fromDate();
+        this.toDate = config.toDate();
+        this.scanWindowDays = config.scanWindowDays();
+        this.maxCloudThreshold = config.maxCloudThreshold();
+        this.cloudWeightFactor = config.cloudWeightFactor();
+        this.defaultExt = config.extension();
+    }
+
+    @Override
+    public Logger getLogger() {
+        return log;
     }
 
     /**
@@ -57,62 +71,43 @@ public class SatelliteStrategy implements ImageProviderStrategy {
         collectMetadata(longIds);
     }
 
+    private Optional<SatelliteScan> getBestScanForSat(SatelliteImage sat) {
+        Path historyFile = cachePath.resolve(sat.getId()).resolve("history.json");
+        return Optional.ofNullable(readMetadataFromDisk(historyFile))
+                .map(FieldSpectralResponse::data)
+                .flatMap(scans -> Optional.ofNullable(findBestScan(scans, sat.getPlanDate())));
+    }
+
+    private Optional<byte[]> downloadAndCache(SatelliteScan best, String id, String indexName, String filePrefix) {
+        String url = best.getUrl(indexName);
+        return Optional.ofNullable(loader.downloadBytes(url))
+                .map(data -> {
+                   String realExt = ImageUtils.determineExtension(url);
+                   Path targetPath = resolvePath(cachePath, filePrefix + ".",
+                           filePrefix + "." + realExt, id, indexName);
+                   writeToDisk(targetPath, data);
+                   return data;
+                });
+    }
+
     @Override
     public void process(ImageSource source) {
         // 1. Проверка типа (Safe Cast)
         if (!(source instanceof SatelliteImage sat) || sat.hasImage()) return;
 
-        // 2. Поиск лучшего скана в истории (history.json)
-        Path historyFile = cachePath.resolve(sat.getId()).resolve("history.json");
-        FieldSpectralResponse response = readMetadataFromDisk(historyFile);
-
-        if (response == null || response.data() == null) {
-            log.warn("Нет данных мониторинга для поля {}", sat.getId());
-            return;
-        }
-
-        SatelliteScan best = findBestScan(response.data(), sat.getPlanDate());
-
-        if (best != null) {
-            // Параметры только для формирования пути файла
-            Map<String, String> pathParams = Map.of(
-                    "index", sat.getIndex().getIndexName(),
-                    "date", best.date()
-            );
-            Path localPath = resolvePath(cachePath, sat.getId(), pathParams);
-
-            // 3. Логика кэша: Сначала диск, потом API
-            byte[] data;
-            if (Files.exists(localPath)) {
-                data = readFromDisk(localPath);
-            } else {
-                data = loader.downloadBytes(best.getUrl(sat.getIndex().getIndexName()));
-                if (data != null) saveToDisk(localPath, data);
-            }
-
-            // 4. Обогащение объекта
-            if (data != null) {
-                sat.setImageBytes(data);
-                sat.setActualDate(LocalDate.parse(best.date())); // Специфика спутника успешно сохранена
-            }
-        }
-    }
-
-    /**
-     * Resolves path following the pattern root/fieldId/indexName/fieldId_date_index.png
-     *
-     * @param root the root directory of the cache.
-     * @param id the identifier of the entity
-     * @param params implementation-specific parameters used to construct the file path.
-     * @return resolved path to the File
-     */
-    @Override
-    public Path resolvePath(Path root, String id, Map<String, String> params) {
-        String index = params.get("index").toLowerCase();
-        String date = params.get("date");
-        String fileName = String.format("%s_%s_%s.png", id, date, index);
-
-        return root.resolve(id).resolve(index).resolve(fileName);
+        getBestScanForSat(sat).ifPresent(best -> {
+            String indexName = sat.getIndex().getIndexName();
+            String filePrefix = sat.getId() + "_" + best.date() + "_" + indexName;
+            Path localPath = resolvePath(cachePath, filePrefix + ".*", filePrefix + "." + defaultExt,
+                    sat.getId(), indexName);
+            readFromDisk(localPath)
+                    .or(() -> downloadAndCache(best, sat.getId(), indexName, filePrefix))
+                    .ifPresent(data -> {
+                        sat.setImageBytes(data);
+                        sat.setActualDate(LocalDate.parse(best.date()));
+                        log.debug("Processed: {} for date {}", indexName, best.date());
+                    });
+        });
     }
 
     @Override
@@ -156,8 +151,8 @@ public class SatelliteStrategy implements ImageProviderStrategy {
                         acquired = true;
                         Map<Long, FieldSpectralResponse> remote = loader.fetchSpectralData(
                                 batch,
-                                config.fromDate(),
-                                config.toDate()
+                                fromDate,
+                                toDate
                         );
                         Map<Long, FieldSpectralResponse> toSave = new HashMap<>();
                         for (Long id : batch) {
@@ -201,11 +196,11 @@ public class SatelliteStrategy implements ImageProviderStrategy {
             LocalDate scanDate = LocalDate.parse(scan.date());
             long daysDiff = ChronoUnit.DAYS.between(targetDate, scanDate);
 
-            if (daysDiff >= 0 && daysDiff <= config.scanWindowDays()) {
-                if (scan.cloud() > config.maxCloudThreshold()) continue;
+            if (daysDiff >= 0 && daysDiff <= scanWindowDays) {
+                if (scan.cloud() > maxCloudThreshold) continue;
 
                 // Вес: дни + облачность с коэффициентом "важности"
-                double currentWeight = daysDiff + (scan.cloud() * config.cloudWeightFactor());
+                double currentWeight = daysDiff + (scan.cloud() * cloudWeightFactor);
 
                 if (currentWeight < minWeight) {
                     minWeight = currentWeight;
@@ -233,26 +228,7 @@ public class SatelliteStrategy implements ImageProviderStrategy {
         return jsonParser.parse(historyFile, FieldSpectralResponse.class);
     }
 
-    private byte[] readFromDisk(Path path) {
-        try {
-            return Files.readAllBytes(path);
-        } catch (IOException e) {
-            log.error("Ошибка чтения изображения из кэша {}: {}", path, e.getMessage());
-            return null;
-        }
-    }
 
-    private void saveToDisk(Path path, byte[] data) {
-        if (data == null) return;
-        try {
-            // Создаем все родительские директории (например, root/fieldId/ndvi/)
-            Files.createDirectories(path.getParent());
-            Files.write(path, data);
-            log.debug("Спутниковый снимок сохранен в кэш: {}", path.getFileName());
-        } catch (IOException e) {
-            log.error("Ошибка записи изображения на диск {}: {}", path, e.getMessage());
-        }
-    }
 
     /*
      * Mass Generation & Pre-caching

--- a/src/main/java/com/viking/field_passport_generator/mapper/ChartMapper.java
+++ b/src/main/java/com/viking/field_passport_generator/mapper/ChartMapper.java
@@ -1,0 +1,65 @@
+package com.viking.field_passport_generator.mapper;
+
+import com.viking.field_passport_generator.data.dto.chart.ChartPoint;
+import com.viking.field_passport_generator.data.dto.satellite.IndexData;
+import com.viking.field_passport_generator.data.dto.satellite.SatelliteScan;
+
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.List;
+
+public class ChartMapper {
+    private final double cloudThreshold;
+    private static final double EPSILON = 1e-6;
+
+    public ChartMapper(double cloudThreshold) {
+        this.cloudThreshold = cloudThreshold;
+    }
+
+    public List<ChartPoint> toChartPoints(List<SatelliteScan> scans) {
+        if (scans == null) return Collections.emptyList();
+
+        return scans.stream()
+                .filter(this::isValidForChart)
+                .map(this::mapToPoint)
+                .toList();
+    }
+
+    private boolean isValidForChart(SatelliteScan scan) {
+        if (scan.cloud() != null && scan.cloud() > cloudThreshold) {
+            return false;
+        }
+
+        double sum = Math.abs(getSafeMean(scan.ndvi())) +
+                Math.abs(getSafeMean(scan.ndwi())) +
+                Math.abs(getSafeMean(scan.msi())) +
+                Math.abs(getSafeMean(scan.gli()));
+
+        return sum > EPSILON;
+    }
+
+    private double getSafeMean(IndexData data) {
+        return (data != null && data.mean() != null) ? data.mean() : 0.0;
+    }
+
+    private double getSafeMax(IndexData data) {
+        return (data != null && data.max() != null) ? data.max() : 0.0;
+    }
+
+    private double getSafeMin(IndexData data) {
+        return (data != null && data.min() != null) ? data.min() : 0.0;
+    }
+
+    private ChartPoint mapToPoint(SatelliteScan scan) {
+        LocalDate date = LocalDate.parse(scan.date());
+        return new ChartPoint(
+                date,
+                getSafeMean(scan.ndvi()),
+                getSafeMin(scan.ndvi()),
+                getSafeMax(scan.ndvi()),
+                getSafeMean(scan.ndwi()),
+                getSafeMean(scan.msi()),
+                getSafeMean(scan.gli())
+        );
+    }
+}

--- a/src/main/java/com/viking/field_passport_generator/mapper/NoteMapper.java
+++ b/src/main/java/com/viking/field_passport_generator/mapper/NoteMapper.java
@@ -1,9 +1,9 @@
 package com.viking.field_passport_generator.mapper;
 
 import com.viking.field_passport_generator.data.dto.RawNote;
-import com.viking.field_passport_generator.model.NoteImage;
-import com.viking.field_passport_generator.model.NoteSection;
-import com.viking.field_passport_generator.model.NoteTableRow;
+import com.viking.field_passport_generator.model.note.NoteImage;
+import com.viking.field_passport_generator.model.note.NoteSection;
+import com.viking.field_passport_generator.model.note.NoteTableRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/main/java/com/viking/field_passport_generator/mapper/PassportMapper.java
+++ b/src/main/java/com/viking/field_passport_generator/mapper/PassportMapper.java
@@ -2,11 +2,11 @@ package com.viking.field_passport_generator.mapper;
 
 import com.viking.field_passport_generator.data.dto.RawFieldData;
 import com.viking.field_passport_generator.model.*;
+import com.viking.field_passport_generator.model.note.NoteSection;
 import com.viking.field_passport_generator.util.YearUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -17,7 +17,8 @@ public class PassportMapper {
      * Превращает сырые данные поля и подготовленный список операций в доменный объект паспорта.
      */
     public static FieldPassport mapToDomain(RawFieldData raw, List<OperationTableRow> operations,
-            NoteSection noteSection, List<TechJournalTableRow> techJournal, List<SatelliteImage> satelliteImages) {
+                                            NoteSection noteSection, List<SatelliteImage> satelliteImages,
+                                            ChartImage chartImage, List<TechJournalTableRow> techJournal) {
         String rawCrop = raw.crop();
 
         int year = YearUtils.extractYear(rawCrop);
@@ -42,9 +43,9 @@ public class PassportMapper {
                 info,
                 operations != null ? operations : Collections.emptyList(),
                 noteSection != null ? noteSection : new NoteSection(Collections.emptyList(), Collections.emptyList()),
-                techJournal != null ? techJournal : Collections.emptyList(),
-                satelliteImages != null ? satelliteImages : Collections.emptyList()
-
+                chartImage,
+                satelliteImages != null ? satelliteImages : Collections.emptyList(),
+                techJournal != null ? techJournal : Collections.emptyList()
         );
     }
 }

--- a/src/main/java/com/viking/field_passport_generator/model/ChartImage.java
+++ b/src/main/java/com/viking/field_passport_generator/model/ChartImage.java
@@ -1,0 +1,54 @@
+package com.viking.field_passport_generator.model;
+
+import com.viking.field_passport_generator.data.dto.chart.ChartPoint;
+
+import java.util.List;
+
+public class ChartImage implements ImageSource {
+    private final String fieldId;
+    private final int year;
+    private final String title;
+    private List<ChartPoint> points;
+    private byte[] imageBytes;
+
+    public ChartImage(String fieldId, int year, String title, List<ChartPoint> points) {
+        this.fieldId = fieldId;
+        this.year = year;
+        this.title = title;
+        this.points = points;
+    }
+
+    @Override
+    public String getId() {
+        return fieldId;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public String getTitle() { return title; }
+
+    @Override
+    public SourceType getType() {
+        return SourceType.CHART;
+    }
+
+    @Override
+    public byte[] getImageBytes() {
+        return imageBytes;
+    }
+
+    public List<ChartPoint> getPoints() {
+        return points;
+    }
+
+    public void setPoints(List<ChartPoint> points) {
+        this.points = points;
+    }
+
+    @Override
+    public void setImageBytes(byte[] bytes) {
+        this.imageBytes = bytes;
+    }
+}

--- a/src/main/java/com/viking/field_passport_generator/model/FieldPassport.java
+++ b/src/main/java/com/viking/field_passport_generator/model/FieldPassport.java
@@ -1,11 +1,14 @@
 package com.viking.field_passport_generator.model;
 
+import com.viking.field_passport_generator.model.note.NoteSection;
+
 import java.util.List;
 
 public record FieldPassport(
     GeneralInfo generalInfo,
     List<OperationTableRow> operations,
     NoteSection notesSection,
-    List<TechJournalTableRow> resources,
-    List<SatelliteImage> satelliteImages
+    ChartImage indexChart,
+    List<SatelliteImage> satelliteImages,
+    List<TechJournalTableRow> resources
 ) {}

--- a/src/main/java/com/viking/field_passport_generator/model/ImageSource.java
+++ b/src/main/java/com/viking/field_passport_generator/model/ImageSource.java
@@ -5,4 +5,9 @@ public interface ImageSource {
     SourceType getType();
     byte[] getImageBytes();
     void setImageBytes(byte[] bytes);
+
+    default boolean hasImage() {
+        byte[] data = getImageBytes();
+        return data != null && data.length > 0;
+    }
 }

--- a/src/main/java/com/viking/field_passport_generator/model/SatelliteImage.java
+++ b/src/main/java/com/viking/field_passport_generator/model/SatelliteImage.java
@@ -39,7 +39,4 @@ public class SatelliteImage implements ImageSource {
     public SpectralIndex getIndex() { return index; }
     public void setIndex(SpectralIndex index) { this.index = index; }
     public String getDescription() { return description; }
-    public boolean hasImage() {
-        return imageBytes != null && imageBytes.length > 0;
-    }
 }

--- a/src/main/java/com/viking/field_passport_generator/model/SourceType.java
+++ b/src/main/java/com/viking/field_passport_generator/model/SourceType.java
@@ -2,5 +2,6 @@ package com.viking.field_passport_generator.model;
 
 public enum SourceType {
     SATELLITE,
-    NOTE
+    NOTE,
+    CHART
 }

--- a/src/main/java/com/viking/field_passport_generator/model/note/NoteImage.java
+++ b/src/main/java/com/viking/field_passport_generator/model/note/NoteImage.java
@@ -1,5 +1,8 @@
-package com.viking.field_passport_generator.model;
+package com.viking.field_passport_generator.model.note;
 
+
+import com.viking.field_passport_generator.model.ImageSource;
+import com.viking.field_passport_generator.model.SourceType;
 
 public class NoteImage implements ImageSource {
     private final String id;
@@ -29,10 +32,6 @@ public class NoteImage implements ImageSource {
     @Override
     public void setImageBytes(byte[] bytes) {
         this.imageBytes = bytes;
-    }
-
-    public boolean hasImage() {
-        return imageBytes != null && imageBytes.length > 0;
     }
 
     public String getComplexIndex() {

--- a/src/main/java/com/viking/field_passport_generator/model/note/NoteSection.java
+++ b/src/main/java/com/viking/field_passport_generator/model/note/NoteSection.java
@@ -1,4 +1,4 @@
-package com.viking.field_passport_generator.model;
+package com.viking.field_passport_generator.model.note;
 
 import java.util.List;
 

--- a/src/main/java/com/viking/field_passport_generator/model/note/NoteTableRow.java
+++ b/src/main/java/com/viking/field_passport_generator/model/note/NoteTableRow.java
@@ -1,4 +1,4 @@
-package com.viking.field_passport_generator.model;
+package com.viking.field_passport_generator.model.note;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/com/viking/field_passport_generator/service/ChartGenerator.java
+++ b/src/main/java/com/viking/field_passport_generator/service/ChartGenerator.java
@@ -1,0 +1,9 @@
+package com.viking.field_passport_generator.service;
+
+import com.viking.field_passport_generator.model.ChartImage;
+
+import java.util.Optional;
+
+public interface ChartGenerator {
+    Optional<byte[]> generateCombinedChart(ChartImage chart);
+}

--- a/src/main/java/com/viking/field_passport_generator/service/ImageSyncService.java
+++ b/src/main/java/com/viking/field_passport_generator/service/ImageSyncService.java
@@ -3,6 +3,7 @@ package com.viking.field_passport_generator.service;
 import com.viking.field_passport_generator.data.dto.RawApiResponse;
 import com.viking.field_passport_generator.data.dto.RawFieldData;
 import com.viking.field_passport_generator.data.dto.RawNotesResponse;
+import com.viking.field_passport_generator.model.ChartImage;
 import com.viking.field_passport_generator.model.FieldPassport;
 import com.viking.field_passport_generator.model.SourceType;
 import com.viking.field_passport_generator.util.JsonDataParser;
@@ -11,6 +12,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.InputStream;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -24,8 +26,19 @@ public class ImageSyncService {
         this.parser = parser;
     }
 
-    public void warmUpNotes(String notesJsonPath) {
-        log.info("Запуск синхронизации изображений для заметок из: {}", notesJsonPath);
+    public void warmUpAll(String notesDataPath, String satelliteDataPath) {
+        warmUpNotes(notesDataPath);
+        warmUpSatelliteMetadata(satelliteDataPath);
+    }
+
+    public void prepareAll(List<FieldPassport> passports) {
+        prepareNoteImages(passports);
+        prepareSatelliteImages(passports);
+        prepareIndexCharts(passports);
+    }
+
+    private void warmUpNotes(String notesJsonPath) {
+        log.info("Starting notes images data synchronization from: {}", notesJsonPath);
         InputStream is = getClass().getClassLoader().getResourceAsStream(notesJsonPath);
         RawNotesResponse notes = parser.parse(is, RawNotesResponse.class);
 
@@ -36,7 +49,7 @@ public class ImageSyncService {
         cacheService.sync(allIds, SourceType.NOTE);
     }
 
-    public void warmUpSatelliteMetadata(String fieldsJsonPath) {
+    private void warmUpSatelliteMetadata(String fieldsJsonPath) {
         log.info("Starting satellite data synchronization from {}", fieldsJsonPath);
 
         // 1. Читаем файл через classloader (как и заметки)
@@ -60,13 +73,23 @@ public class ImageSyncService {
         cacheService.sync(allIds, SourceType.SATELLITE);
     }
 
-    public void prepareSatelliteImages(List<FieldPassport> passports) {
+    private void prepareSatelliteImages(List<FieldPassport> passports) {
         log.info("Подготовка спутниковых снимков для {} паспортов", passports.size());
         passports.forEach(p -> cacheService.fillImages(p.satelliteImages()));
     }
 
-    public void prepareNoteImages(List<FieldPassport> passports) {
+    private void prepareNoteImages(List<FieldPassport> passports) {
         log.info("Подготовка фотографий заметок для {} сезонов", passports.size());
         passports.forEach(p -> cacheService.fillImages(p.notesSection().images()));
+    }
+
+    private void prepareIndexCharts(List<FieldPassport> passports) {
+        log.info("Подготовка изображений графиков для {} паспортов", passports.size());
+
+        List<ChartImage> charts = passports.stream()
+                .map(FieldPassport::indexChart)
+                .filter(Objects::nonNull)
+                .toList();
+        cacheService.fillImages(charts);
     }
 }

--- a/src/main/java/com/viking/field_passport_generator/service/PdfGeneratorService.java
+++ b/src/main/java/com/viking/field_passport_generator/service/PdfGeneratorService.java
@@ -1,6 +1,8 @@
 package com.viking.field_passport_generator.service;
 
 import com.viking.field_passport_generator.model.*;
+import com.viking.field_passport_generator.model.note.NoteImage;
+import com.viking.field_passport_generator.model.note.NoteTableRow;
 import com.viking.field_passport_generator.util.NoteImageComparators;
 import com.viking.field_passport_generator.util.PdfUIHelper;
 import org.openpdf.text.Document;
@@ -141,6 +143,11 @@ public class PdfGeneratorService implements PassportGeneratorService {
 
         document.newPage();
         document.add(PdfUIHelper.createPhotoGrid(writer, photoMap));
+
+        // --- Section 4. Spectral indices ---
+        document.newPage();
+        ChartImage chartImage = passport.indexChart();
+        PdfUIHelper.addChartImage(document, chartImage);
 
         // --- Section 6. Satellite Images ---
         document.newPage();

--- a/src/main/java/com/viking/field_passport_generator/service/XChartGeneratorImpl.java
+++ b/src/main/java/com/viking/field_passport_generator/service/XChartGeneratorImpl.java
@@ -77,7 +77,6 @@ public class XChartGeneratorImpl implements ChartGenerator {
         styler.setPlotGridVerticalLinesVisible(false);
         styler.setPlotGridHorizontalLinesVisible(true);
         styler.setPlotGridLinesStroke(new BasicStroke(1.0f));
-        styler.setPlotGridLinesColor(new Color(230, 230, 230));
         styler.setPlotGridLinesColor(new Color(240, 240, 240));
         styler.setLegendPosition(Styler.LegendPosition.InsideNE);
         styler.setLegendLayout(Styler.LegendLayout.Vertical);

--- a/src/main/java/com/viking/field_passport_generator/service/XChartGeneratorImpl.java
+++ b/src/main/java/com/viking/field_passport_generator/service/XChartGeneratorImpl.java
@@ -1,0 +1,163 @@
+package com.viking.field_passport_generator.service;
+
+import com.viking.field_passport_generator.config.ChartConfig;
+import com.viking.field_passport_generator.data.dto.chart.ChartPoint;
+import com.viking.field_passport_generator.model.ChartImage;
+import org.knowm.xchart.BitmapEncoder;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.XYSeries;
+import org.knowm.xchart.style.Styler;
+import org.knowm.xchart.style.XYStyler;
+import org.knowm.xchart.style.markers.SeriesMarkers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.*;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.ZoneId;
+import java.util.*;
+import java.util.List;
+
+public class XChartGeneratorImpl implements ChartGenerator {
+    private static final Logger log = LoggerFactory.getLogger(XChartGeneratorImpl.class);
+
+    private static final String SERIES_NDVI_MEAN = "NDVI средний";
+    private static final String SERIES_NDVI_MAX = "NDVI макс.";
+    private static final String SERIES_NDVI_MIN = "NDVI мин.";
+    private static final String SERIES_NDWI_MEAN = "NDWI (влага) средний";
+    private static final String SERIES_MSI_MEAN = "MSI (стресс) средний";
+    private static final String SERIES_GLI_MEAN = "GLI (зелёный лист) средний";
+
+    private static final Color COLOR_NDVI_MEAN = new Color(31, 119, 180); // Темно-синий
+    private static final Color COLOR_NDVI_MAX = new Color(140, 86, 75);  // Коричневый
+    private static final Color COLOR_NDVI_MIN = new Color(188, 189, 34);  // Оливковый
+    private static final Color COLOR_NDWI_MEAN = new Color(0, 0, 255);    // Ярко-синий
+    private static final Color COLOR_MSI_MEAN = new Color(255, 0, 0);    // Красный
+    private static final Color COLOR_GLI_MEAN = new Color(0, 255, 0);
+
+    private final int width;
+    private final int height;
+    private final Font customFont;
+    private final ZoneId timezone;
+
+    public XChartGeneratorImpl(ChartConfig config) {
+        this.width = config.width();
+        this.height = config.height();
+        this.customFont = loadFontFromResource(config.fontPath());
+        this.timezone = config.timezone();
+    }
+
+    @Override
+    public Optional<byte[]> generateCombinedChart(ChartImage chart) {
+        XYChart xyChart = new XYChartBuilder()
+                .width(width)
+                .height(height)
+                .title(chart.getTitle())
+                .yAxisTitle("Спектральные индексы")
+                .build();
+
+        XYStyler styler = xyChart.getStyler();
+        styler.setLocale(Locale.forLanguageTag("ru"));
+        styler.setDatePattern("d MMM");
+        styler.setXAxisTickMarkSpacingHint(100);
+        styler.setYAxisTickMarkSpacingHint(50);
+        styler.setPlotContentSize(0.98);
+
+        styler.setChartTitleFont(customFont.deriveFont(Font.PLAIN, 22f));
+        styler.setChartTitlePadding(10);
+        styler.setAxisTickLabelsFont(customFont.deriveFont(Font.PLAIN, 14f));
+        styler.setLegendFont(customFont.deriveFont(Font.PLAIN, 12f));
+        styler.setAxisTitleFont(customFont.deriveFont(Font.PLAIN, 14f));
+        styler.setAxisTitlePadding(20);
+
+        styler.setChartBackgroundColor(Color.WHITE);
+        styler.setPlotGridLinesVisible(true);
+        styler.setPlotGridVerticalLinesVisible(false);
+        styler.setPlotGridHorizontalLinesVisible(true);
+        styler.setPlotGridLinesStroke(new BasicStroke(1.0f));
+        styler.setPlotGridLinesColor(new Color(230, 230, 230));
+        styler.setPlotGridLinesColor(new Color(240, 240, 240));
+        styler.setLegendPosition(Styler.LegendPosition.InsideNE);
+        styler.setLegendLayout(Styler.LegendLayout.Vertical);
+        styler.setMarkerSize(0);
+
+        List<Date> xData = new ArrayList<>();
+        List<Double> ndviMean = new ArrayList<>();
+        List<Double> ndviMin = new ArrayList<>();
+        List<Double> ndviMax = new ArrayList<>();
+        List<Double> ndwiMean = new ArrayList<>();
+        List<Double> msiMean = new ArrayList<>();
+        List<Double> gliMean = new ArrayList<>();
+
+        for (ChartPoint p : chart.getPoints()) {
+            xData.add(p.toDate(timezone));
+            ndviMean.add(p.ndviMean());
+            ndviMin.add(p.ndviMin());
+            ndviMax.add(p.ndviMax());
+            ndwiMean.add(p.ndwiMean());
+            msiMean.add(p.msiMean());
+            gliMean.add(p.gliMean());
+        }
+
+        if (xData.isEmpty()) {
+            log.warn("Не удалось сгенерировать график для '{}': список точек пуст. Год: {}",
+                    chart.getTitle(), chart.getYear());
+            return Optional.empty();
+        }
+
+        double minX = (double) xData.getFirst().getTime();
+        double maxX = (double) xData.getLast().getTime();
+
+        styler.setXAxisMin(minX);
+        styler.setXAxisMax(maxX);
+
+        addSeries(xyChart, SERIES_NDVI_MEAN, xData, ndviMean, COLOR_NDVI_MEAN);
+        addSeries(xyChart, SERIES_NDVI_MAX, xData, ndviMax, COLOR_NDVI_MAX);
+        addSeries(xyChart, SERIES_NDVI_MIN, xData, ndviMin, COLOR_NDVI_MIN);
+        addSeries(xyChart, SERIES_NDWI_MEAN, xData, ndwiMean, COLOR_NDWI_MEAN);
+        addSeries(xyChart, SERIES_MSI_MEAN, xData, msiMean, COLOR_MSI_MEAN);
+        addSeries(xyChart, SERIES_GLI_MEAN, xData, gliMean, COLOR_GLI_MEAN);
+
+        try {
+            byte[] bytes = BitmapEncoder.getBitmapBytes(xyChart, org.knowm.xchart.BitmapEncoder.BitmapFormat.PNG);
+            return Optional.ofNullable(bytes);
+        } catch (IOException e) {
+            log.error("Error generating chart: {}. Reason: {}", chart.getTitle(), e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private Font loadFontFromResource(String resourcePath) {
+        try (InputStream is = getClass().getClassLoader().getResourceAsStream(resourcePath)) {
+            if (is == null) {
+                return getDefaultFallbackFont("Resource not found: " + resourcePath);
+            }
+            Font font = Font.createFont(Font.TRUETYPE_FONT, is);
+            GraphicsEnvironment.getLocalGraphicsEnvironment().registerFont(font);
+            return font;
+        } catch (FontFormatException e) {
+            return getDefaultFallbackFont("Invalid font format: " + resourcePath);
+        } catch (IOException e) {
+            return getDefaultFallbackFont("I/O error while reading font: " + resourcePath);
+        }
+    }
+
+    private Font getDefaultFallbackFont(String reason) {
+        log.warn(reason);
+        return new Font(Font.SANS_SERIF, Font.PLAIN, 12);
+    }
+
+    private void addSeries(XYChart chart, String name, List<Date> x, List<Double> y, Color color) {
+        if (y.isEmpty() || y.stream().allMatch(Objects::isNull)) {
+            log.warn("The Y axis is empty");
+            return;
+        }
+        XYSeries series = chart.addSeries(name, x, y);
+        series.setLineColor(color);
+        series.setLineWidth(2.0f);
+        series.setMarker(SeriesMarkers.NONE);
+
+    }
+}

--- a/src/main/java/com/viking/field_passport_generator/util/NoteImageComparators.java
+++ b/src/main/java/com/viking/field_passport_generator/util/NoteImageComparators.java
@@ -1,6 +1,6 @@
 package com.viking.field_passport_generator.util;
 
-import com.viking.field_passport_generator.model.NoteImage;
+import com.viking.field_passport_generator.model.note.NoteImage;
 
 import java.util.Comparator;
 

--- a/src/main/java/com/viking/field_passport_generator/util/PdfUIHelper.java
+++ b/src/main/java/com/viking/field_passport_generator/util/PdfUIHelper.java
@@ -1,6 +1,7 @@
 package com.viking.field_passport_generator.util;
 
 import com.viking.field_passport_generator.model.*;
+import com.viking.field_passport_generator.model.note.NoteTableRow;
 import org.openpdf.text.*;
 import org.openpdf.text.Font;
 import org.openpdf.text.Image;
@@ -10,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.*;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.Duration;
@@ -404,6 +406,31 @@ public final class PdfUIHelper {
             table.addCell(createStyledCell(new Phrase(row.period(), FONT_TABLE_BODY), null, Element.ALIGN_LEFT));
         }
         return table;
+    }
+
+    public static void addChartImage(Document document, ChartImage chartImage) {
+        PdfPTable table = new PdfPTable(1);
+        table.setWidthPercentage(100f);
+        table.setSpacingBefore(20f);
+        table.setKeepTogether(true);
+
+        PdfPCell cell = new PdfPCell();
+        cell.setBorder(Rectangle.NO_BORDER);
+        cell.setHorizontalAlignment(Element.ALIGN_CENTER);
+
+        Paragraph title = createSectionTitle("Раздел 4. Индексы");
+        title.setAlignment(Element.ALIGN_LEFT);
+        cell.addElement(title);
+        try {
+            Image img = Image.getInstance(chartImage.getImageBytes());
+            img.setAlignment(Image.ALIGN_CENTER);
+            cell.addElement(img);
+        } catch (Exception e) {
+            log.error("Error rendering chartImage: {}", e.getMessage());
+            cell.addElement(new Phrase("Ошибка отрисовки графика"));
+        }
+        table.addCell(cell);
+        document.add(table);
     }
 
     /**

--- a/src/test/java/com/viking/field_passport_generator/util/NoteImageComparatorsTest.java
+++ b/src/test/java/com/viking/field_passport_generator/util/NoteImageComparatorsTest.java
@@ -1,6 +1,6 @@
 package com.viking.field_passport_generator.util;
 
-import com.viking.field_passport_generator.model.NoteImage;
+import com.viking.field_passport_generator.model.note.NoteImage;
 import org.junit.jupiter.api.Test;
 
 import java.util.Comparator;


### PR DESCRIPTION
Closes #13 

Summary:
This PR completes Section 4 of the field passport by implementing spectral indices chart generation. It also refactors the dependency injection container to simplify assembly and improve future maintainability.

Key Changes:

- Chart Generation: Introduced ChartStrategy with XChart implementation to generate combined charts for NDVI, NDWI, MSI, and GLI indices.
- Chart Caching: Charts are cached as PNG files under cache/images/{fieldId}/charts/ for reuse.
- PDF Integration: Added chart rendering to PdfUIHelper (kept together with title via PdfPTable container).
- AppContainer Refactoring: Simplified component assembly using factory methods, decoupling configuration from service wiring.
- Timezone Handling: Centralized ZoneId across chart generation and date conversion to avoid hardcoded defaults.